### PR TITLE
Added feature that can query block hashes to other peer

### DIFF
--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -176,16 +176,22 @@ namespace Libplanet.Tests
 
             Assert.Equal(
                 new[] { block1.Hash, block2.Hash, block3.Hash, },
-                _blockchain.FindNextHashes(new[] { block0.Hash }));
+                _blockchain.FindNextHashes(
+                    new BlockLocator(new[] { block0.Hash })));
             Assert.Equal(
                 new[] { block2.Hash, block3.Hash },
-                _blockchain.FindNextHashes(new[] { block1.Hash, block0.Hash }));
+                _blockchain.FindNextHashes(
+                    new BlockLocator(new[] { block1.Hash, block0.Hash })));
             Assert.Equal(
                 new[] { block1.Hash, block2.Hash },
-                _blockchain.FindNextHashes(new[] { block0.Hash }, block2.Hash));
+                _blockchain.FindNextHashes(
+                    new BlockLocator(new[] { block0.Hash }),
+                    stop: block2.Hash));
             Assert.Equal(
                 new[] { block1.Hash, block2.Hash },
-                _blockchain.FindNextHashes(new[] { block0.Hash }, count: 2));
+                _blockchain.FindNextHashes(
+                    new BlockLocator(new[] { block0.Hash }),
+                    count: 2));
         }
     }
 }

--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
@@ -162,6 +163,29 @@ namespace Libplanet.Tests
             Assert.NotEmpty(_blockchain.Addresses);
             Assert.Contains(_fx.Transaction1, _blockchain.Addresses[_fx.Transaction1.Recipient]);
             Assert.DoesNotContain(_fx.Transaction2, _blockchain.Addresses[_fx.Transaction1.Recipient]);
+        }
+
+        [Fact]
+        public void CanFindNextHashes()
+        {
+            _blockchain.Append(_fx.Block1);
+            var block0 = _fx.Block1;
+            var block1 = _blockchain.MineBlock(_fx.Address1);
+            var block2 = _blockchain.MineBlock(_fx.Address1);
+            var block3 = _blockchain.MineBlock(_fx.Address1);
+
+            Assert.Equal(
+                new[] { block1.Hash, block2.Hash, block3.Hash, },
+                _blockchain.FindNextHashes(new[] { block0.Hash }));
+            Assert.Equal(
+                new[] { block2.Hash, block3.Hash },
+                _blockchain.FindNextHashes(new[] { block1.Hash, block0.Hash }));
+            Assert.Equal(
+                new[] { block1.Hash, block2.Hash },
+                _blockchain.FindNextHashes(new[] { block0.Hash }, block2.Hash));
+            Assert.Equal(
+                new[] { block1.Hash, block2.Hash },
+                _blockchain.FindNextHashes(new[] { block0.Hash }, count: 2));
         }
     }
 }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -3,16 +3,24 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Net;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Libplanet.Tests.Net
 {
-    public class SwarmTest
+    public class SwarmTest : IDisposable
     {
+        private readonly FileStoreFixture _fx1;
+        private readonly FileStoreFixture _fx2;
+        private readonly FileStoreFixture _fx3;
+
+        private readonly List<Blockchain<BaseAction>> _blockchains;
         private readonly List<Swarm> _swarms;
 
         public SwarmTest(ITestOutputHelper output)
@@ -23,6 +31,18 @@ namespace Libplanet.Tests.Net
                 .WriteTo.TestOutput(output, outputTemplate: "{Timestamp:HH:mm:ss}[@{Swarm_listenUrl}][{ThreadId}] - {Message}")
                 .CreateLogger()
                 .ForContext<SwarmTest>();
+
+            _fx1 = new FileStoreFixture();
+            _fx2 = new FileStoreFixture();
+            _fx3 = new FileStoreFixture();
+
+            _blockchains = new List<Blockchain<BaseAction>>
+            {
+                new Blockchain<BaseAction>(_fx1.Store),
+                new Blockchain<BaseAction>(_fx2.Store),
+                new Blockchain<BaseAction>(_fx3.Store),
+            };
+
             _swarms = new List<Swarm>
             {
                 new Swarm(
@@ -40,12 +60,21 @@ namespace Libplanet.Tests.Net
             };
         }
 
+        public void Dispose()
+        {
+            _fx1.Dispose();
+            _fx2.Dispose();
+            _fx3.Dispose();
+        }
+
         [Fact]
         public async Task WorksAsExpected()
         {
             Swarm a = _swarms[0];
             Swarm b = _swarms[1];
             Swarm c = _swarms[2];
+
+            Blockchain<BaseAction> chain = _blockchains[0];
 
             DateTime lastDistA;
             Peer aAsPeer;
@@ -59,15 +88,15 @@ namespace Libplanet.Tests.Net
                 {
                     await a.InitContextAsync();
 
-                    var at = Task.Run(async () => await a.RunAsync(250));
+                    var at = Task.Run(async () => await a.RunAsync(chain, 250));
                     await b.AddPeersAsync(new[] { a.AsPeer });
-                    var bt = Task.Run(async () => await b.RunAsync(250));
+                    var bt = Task.Run(async () => await b.RunAsync(chain, 250));
                     await EnsureExchange(a, b);
                     Assert.Equal(new[] { b.AsPeer }.ToImmutableHashSet(), a.ToImmutableHashSet());
                     Assert.Equal(new[] { a.AsPeer }.ToImmutableHashSet(), b.ToImmutableHashSet());
 
                     await c.AddPeersAsync(new[] { a.AsPeer });
-                    var ct = Task.Run(async () => await c.RunAsync(250));
+                    var ct = Task.Run(async () => await c.RunAsync(chain, 250));
                     await EnsureExchange(a, c);
                     await EnsureExchange(a, b);
 
@@ -168,12 +197,14 @@ namespace Libplanet.Tests.Net
         public async Task CanBeCancelled()
         {
             Swarm swarm = _swarms[0];
+            Blockchain<BaseAction> chain = _blockchains[0];
             var cts = new CancellationTokenSource();
 
             try
             {
                 await swarm.InitContextAsync();
-                var at = Task.Run(async () => await swarm.RunAsync(250, cts.Token));
+                var at = Task.Run(
+                    async () => await swarm.RunAsync(chain, 250, cts.Token));
 
                 cts.Cancel();
                 await Assert.ThrowsAsync<TaskCanceledException>(async () => await at);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -161,6 +162,26 @@ namespace Libplanet.Tests.Net
 
             Assert.NotEqual(a, b);
             Assert.True(a.KeyEquals(b));
+        }
+
+        [Fact]
+        public async Task CanBeCancelled()
+        {
+            Swarm swarm = _swarms[0];
+            var cts = new CancellationTokenSource();
+
+            try
+            {
+                await swarm.InitContextAsync();
+                var at = Task.Run(async () => await swarm.RunAsync(250, cts.Token));
+
+                cts.Cancel();
+                await Assert.ThrowsAsync<TaskCanceledException>(async () => await at);
+            }
+            finally
+            {
+                await swarm.DisposeAsync();
+            }
         }
 
         private async Task EnsureRecvAsync(Swarm swarm, Peer peer = null, DateTime? lastReceived = null)

--- a/Libplanet/BlockLocator.cs
+++ b/Libplanet/BlockLocator.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+namespace Libplanet
+{
+    internal class BlockLocator : IEnumerable<HashDigest<SHA256>>
+    {
+        private readonly IEnumerable<HashDigest<SHA256>> _impl;
+
+        public BlockLocator(IEnumerable<HashDigest<SHA256>> hashes)
+        {
+            _impl = hashes;
+        }
+
+        public IEnumerator<HashDigest<SHA256>> GetEnumerator()
+        {
+            return _impl.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _impl.GetEnumerator();
+        }
+    }
+}

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -217,8 +217,7 @@ namespace Libplanet
             return block;
         }
 
-        internal HashDigest<SHA256> FindBranchPoint(
-            IEnumerable<HashDigest<SHA256>> locator)
+        internal HashDigest<SHA256> FindBranchPoint(BlockLocator locator)
         {
             // Assume locator is sorted descending by height.
             foreach (HashDigest<SHA256> hash in locator)
@@ -233,7 +232,7 @@ namespace Libplanet
         }
 
         internal IEnumerable<HashDigest<SHA256>> FindNextHashes(
-            IEnumerable<HashDigest<SHA256>> locator,
+            BlockLocator locator,
             HashDigest<SHA256>? stop = null,
             int count = 500)
         {

--- a/Libplanet/Net/NetMQSocketExtension.cs
+++ b/Libplanet/Net/NetMQSocketExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NetMQ;
 
@@ -12,10 +13,21 @@ namespace Libplanet.Net
             int? timeout = null,
             int delay = 100)
         {
+            await SendFrameAsync(
+                socket, data, CancellationToken.None, timeout, delay);
+        }
+
+        public static async Task SendFrameAsync(
+            this IOutgoingSocket socket,
+            byte[] data,
+            CancellationToken cancellationToken,
+            int? timeout = null,
+            int delay = 100)
+        {
             int elapsed = 0;
             while (!socket.TrySendFrame(data))
             {
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
 
                 elapsed += 100;
                 if (elapsed > timeout)
@@ -32,10 +44,21 @@ namespace Libplanet.Net
             int? timeout = null,
             int delay = 100)
         {
+            await SendMultipartMessageAsync(
+                socket, message, CancellationToken.None, timeout, delay);
+        }
+
+        public static async Task SendMultipartMessageAsync(
+            this IOutgoingSocket socket,
+            NetMQMessage message,
+            CancellationToken cancellationToken,
+            int? timeout = null,
+            int delay = 100)
+        {
             int elapsed = 0;
             while (!socket.TrySendMultipartMessage(message))
             {
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
 
                 elapsed += 100;
                 if (elapsed > timeout)
@@ -51,11 +74,21 @@ namespace Libplanet.Net
             int? timeout = null,
             int delay = 100)
         {
+            return await ReceiveMultipartMessageAsync(
+                socket, CancellationToken.None, timeout, delay);
+        }
+
+        public static async Task<NetMQMessage> ReceiveMultipartMessageAsync(
+            this IReceivingSocket socket,
+            CancellationToken cancellationToken,
+            int? timeout = null,
+            int delay = 100)
+        {
             NetMQMessage message = new NetMQMessage();
             int elapsed = 0;
             while (!socket.TryReceiveMultipartMessage(ref message))
             {
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
 
                 elapsed += delay;
                 if (elapsed > timeout)

--- a/Libplanet/Net/NetMQSocketExtension.cs
+++ b/Libplanet/Net/NetMQSocketExtension.cs
@@ -5,13 +5,13 @@ using NetMQ;
 
 namespace Libplanet.Net
 {
-    public static class NetMQSocketExtension
+    internal static class NetMQSocketExtension
     {
         public static async Task SendFrameAsync(
             this IOutgoingSocket socket,
             byte[] data,
-            int? timeout = null,
-            int delay = 100)
+            TimeSpan? timeout = null,
+            TimeSpan? delay = null)
         {
             await SendFrameAsync(
                 socket, data, CancellationToken.None, timeout, delay);
@@ -21,15 +21,17 @@ namespace Libplanet.Net
             this IOutgoingSocket socket,
             byte[] data,
             CancellationToken cancellationToken,
-            int? timeout = null,
-            int delay = 100)
+            TimeSpan? timeout = null,
+            TimeSpan? delay = null)
         {
-            int elapsed = 0;
+            TimeSpan delayNotNull = delay ?? TimeSpan.FromMilliseconds(100);
+            TimeSpan elapsed = TimeSpan.Zero;
+
             while (!socket.TrySendFrame(data))
             {
-                await Task.Delay(delay, cancellationToken);
+                await Task.Delay(delayNotNull, cancellationToken);
 
-                elapsed += 100;
+                elapsed += delayNotNull;
                 if (elapsed > timeout)
                 {
                     throw new TimeoutException(
@@ -41,8 +43,8 @@ namespace Libplanet.Net
         public static async Task SendMultipartMessageAsync(
             this IOutgoingSocket socket,
             NetMQMessage message,
-            int? timeout = null,
-            int delay = 100)
+            TimeSpan? timeout = null,
+            TimeSpan? delay = null)
         {
             await SendMultipartMessageAsync(
                 socket, message, CancellationToken.None, timeout, delay);
@@ -52,15 +54,17 @@ namespace Libplanet.Net
             this IOutgoingSocket socket,
             NetMQMessage message,
             CancellationToken cancellationToken,
-            int? timeout = null,
-            int delay = 100)
+            TimeSpan? timeout = null,
+            TimeSpan? delay = null)
         {
-            int elapsed = 0;
+            TimeSpan delayNotNull = delay ?? TimeSpan.FromMilliseconds(100);
+            TimeSpan elapsed = TimeSpan.Zero;
+
             while (!socket.TrySendMultipartMessage(message))
             {
-                await Task.Delay(delay, cancellationToken);
+                await Task.Delay(delayNotNull, cancellationToken);
 
-                elapsed += 100;
+                elapsed += delayNotNull;
                 if (elapsed > timeout)
                 {
                     throw new TimeoutException(
@@ -71,8 +75,8 @@ namespace Libplanet.Net
 
         public static async Task<NetMQMessage> ReceiveMultipartMessageAsync(
             this IReceivingSocket socket,
-            int? timeout = null,
-            int delay = 100)
+            TimeSpan? timeout = null,
+            TimeSpan? delay = null)
         {
             return await ReceiveMultipartMessageAsync(
                 socket, CancellationToken.None, timeout, delay);
@@ -81,16 +85,18 @@ namespace Libplanet.Net
         public static async Task<NetMQMessage> ReceiveMultipartMessageAsync(
             this IReceivingSocket socket,
             CancellationToken cancellationToken,
-            int? timeout = null,
-            int delay = 100)
+            TimeSpan? timeout = null,
+            TimeSpan? delay = null)
         {
             NetMQMessage message = new NetMQMessage();
-            int elapsed = 0;
+            TimeSpan delayNotNull = delay ?? TimeSpan.FromMilliseconds(100);
+            TimeSpan elapsed = TimeSpan.Zero;
+
             while (!socket.TryReceiveMultipartMessage(ref message))
             {
-                await Task.Delay(delay, cancellationToken);
+                await Task.Delay(delayNotNull, cancellationToken);
 
-                elapsed += delay;
+                elapsed += delayNotNull;
                 if (elapsed > timeout)
                 {
                     throw new TimeoutException(

--- a/Libplanet/Net/PeerNotFoundException.cs
+++ b/Libplanet/Net/PeerNotFoundException.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Libplanet.Net
+{
+    [Serializable]
+    public class PeerNotFoundException : SwarmException
+    {
+        public PeerNotFoundException()
+        {
+        }
+
+        public PeerNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        public PeerNotFoundException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected PeerNotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -472,10 +472,9 @@ namespace Libplanet.Net
 
                     case MessageType.GetBlocks:
                         int requestedHashCount = message[2].ConvertToInt32();
-                        List<HashDigest<SHA256>> locator = message
-                            .Skip(3).Take(requestedHashCount)
-                            .Select(f => new HashDigest<SHA256>(f.ToByteArray()))
-                            .ToList();
+                        var locator = new BlockLocator(
+                            message.Skip(3).Take(requestedHashCount)
+                            .Select(f => new HashDigest<SHA256>(f.ToByteArray())));
                         HashDigest<SHA256> stop = new HashDigest<SHA256>(
                             message.Skip(2 + requestedHashCount).First().ToByteArray());
                         IEnumerable<HashDigest<SHA256>> inventories = blockchain

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
+using Libplanet.Action;
 using Libplanet.Crypto;
 using NetMQ;
 using NetMQ.Sockets;
@@ -284,21 +285,25 @@ namespace Libplanet.Net
             return GetEnumerator();
         }
 
-        public async Task RunAsync(int distributeInterval)
+        public async Task RunAsync<T>(
+            Blockchain<T> blockchain, int distributeInterval)
+            where T : IAction
         {
-            await RunAsync(distributeInterval, CancellationToken.None);
+            await RunAsync(blockchain, distributeInterval, CancellationToken.None);
         }
 
-        public async Task RunAsync(
+        public async Task RunAsync<T>(
+            Blockchain<T> blockchain,
             int distributeInterval,
             CancellationToken cancellationToken)
+            where T : IAction
         {
             CheckEntered();
 
             await Task.WhenAll(
                 RepeatDeltaDistributionAsync(
                     distributeInterval, cancellationToken),
-                ReceiveMessageAsync(cancellationToken),
+                ReceiveMessageAsync(blockchain, cancellationToken),
                 ProcessDeltaAsync(cancellationToken));
         }
 
@@ -377,7 +382,9 @@ namespace Libplanet.Net
             }
         }
 
-        private async Task ReceiveMessageAsync(CancellationToken cancellationToken)
+        private async Task ReceiveMessageAsync<T>(
+            Blockchain<T> blockchain, CancellationToken cancellationToken)
+            where T : IAction
         {
             CheckEntered();
 


### PR DESCRIPTION
it's first PR of P2P exchange protocol [Bitcoin P2P protocol](https://bitcoin.org/en/developer-reference#p2p-network).

- Added `GetBlocksAsync()` to `Swarm` (like [`getblocks`](https://bitcoin.org/en/developer-reference#getblocks) at Bitcoin)
  - for this, Added `LocateBlocks()` to `Blockchain` to query blockhashes
- Implement reply of `GetBlockAsync()` on `RunAsync()` (like [`inv`](https://bitcoin.org/en/developer-reference#inv) at Bitcoin)

In addition, the following are also not directly related to P2P implementations.

- Changed `Swarm._dealers`'s key type from `Uri` to `Address` to lookup peer easily.
- Hide methods(e.g. `Swarm.ProcessDeltaAsync()`) that do not need to be exposed to the outside.
- Added cancellation support to `Swarm`'s async methods.

@dahlia @kijun @ipdae 