### PR TITLE
Separate message related features from Swarm.

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -244,15 +244,19 @@ namespace Libplanet.Tests.Net
 
                 await Assert.ThrowsAsync<PeerNotFoundException>(
                     async () => await swarmB.GetBlocksAsync(
-                        swarmA.AsPeer, new[] { genesis.Hash }));
+                        swarmA.AsPeer, new[] { genesis.Hash }, null));
 
                 await swarmB.AddPeersAsync(new[] { swarmA.AsPeer });
 
-                IEnumerable<HashDigest<SHA256>> inventories =
+                IEnumerable<HashDigest<SHA256>> inventories1 =
                     await swarmB.GetBlocksAsync(
-                        swarmA.AsPeer, new[] { genesis.Hash });
+                        swarmA.AsPeer, new[] { genesis.Hash }, null);
+                Assert.Equal(new[] { block1.Hash, block2.Hash }, inventories1);
 
-                Assert.Equal(new[] { block1.Hash, block2.Hash }, inventories);
+                IEnumerable<HashDigest<SHA256>> inventories2 =
+                    await swarmB.GetBlocksAsync(
+                        swarmA.AsPeer, new[] { genesis.Hash }, block1.Hash);
+                Assert.Equal(new[] { block1.Hash }, inventories2);
 
                 // TODO Test swarmB.GetData(swarmA.AsPeer, invetories);
             }

--- a/Libplanet/Net/Messages/GetBlocks.cs
+++ b/Libplanet/Net/Messages/GetBlocks.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class GetBlocks : Message
+    {
+        public GetBlocks(
+            BlockLocator locator, HashDigest<SHA256>? stop)
+        {
+            Locator = locator;
+            Stop = stop;
+        }
+
+        public BlockLocator Locator { get; }
+
+        public HashDigest<SHA256>? Stop { get; }
+
+        protected override MessageType Type => MessageType.GetBlocks;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(
+                    NetworkOrderBitsConverter.GetBytes(Locator.Count()));
+
+                foreach (HashDigest<SHA256> hash in Locator)
+                {
+                    yield return new NetMQFrame(hash.ToByteArray());
+                }
+
+                if (Stop is HashDigest<SHA256> stop)
+                {
+                    yield return new NetMQFrame(stop.ToByteArray());
+                }
+                else
+                {
+                    yield return NetMQFrame.Empty;
+                }
+            }
+        }
+
+        public static Message ParseBody(NetMQFrame[] frames)
+        {
+            int requestedHashCount = frames[0].ConvertToInt32();
+            var locator = new BlockLocator(
+                frames.Skip(1).Take(requestedHashCount)
+                .Select(f => f.ConvertToHashDigest<SHA256>()));
+            HashDigest<SHA256>? stop = frames[1 + requestedHashCount].IsEmpty
+                ? default(HashDigest<SHA256>?)
+                : frames[1 + requestedHashCount].ConvertToHashDigest<SHA256>();
+            return new GetBlocks(locator, stop);
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Inventory.cs
+++ b/Libplanet/Net/Messages/Inventory.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class Inventory : Message
+    {
+        public Inventory(
+            IEnumerable<HashDigest<SHA256>> blockHashes)
+        {
+            BlockHashes = blockHashes;
+        }
+
+        // FIXME add discriminator to determine hash is tx or block.
+        public IEnumerable<HashDigest<SHA256>> BlockHashes { get; }
+
+        protected override MessageType Type => MessageType.Inventory;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(
+                    NetworkOrderBitsConverter.GetBytes(BlockHashes.Count()));
+
+                foreach (var hash in BlockHashes)
+                {
+                    yield return new NetMQFrame(hash.ToByteArray());
+                }
+            }
+        }
+
+        public static Message Parse(NetMQFrame[] frames)
+        {
+            int count = frames[0].ConvertToInt32();
+            return new Inventory(
+                frames.Skip(1).Take(count)
+                .Select(f => f.ConvertToHashDigest<SHA256>())
+                .ToList());
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Crypto;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal abstract class Message
+    {
+        protected enum MessageType : byte
+        {
+            /// <summary>
+            /// Check message to determine peer is alive.
+            /// </summary>
+            Ping = 0x01,
+
+            /// <summary>
+            /// Reply of `Ping`.
+            /// </summary>
+            Pong = 0x02,
+
+            /// <summary>
+            /// Peer's delta set to sync peer list.
+            /// </summary>
+            PeerSetDelta = 0x03,
+
+            /// <summary>
+            /// Request to query block hashes.
+            /// </summary>
+            GetBlocks = 0x04,
+
+            /// <summary>
+            /// Inventory to transfer blocks or txs.
+            /// </summary>
+            Inventory = 0x05,
+        }
+
+        public Address? Identity { get; set; }
+
+        protected abstract MessageType Type { get; }
+
+        protected abstract IEnumerable<NetMQFrame> DataFrames { get; }
+
+        public static Message Parse(NetMQMessage raw, bool reply)
+        {
+            if (raw.FrameCount == 0)
+            {
+                throw new ArgumentException("Can't parse empty NetMQMessage.");
+            }
+
+            // (reply == true)  [type, sign, pubkey, frames...]
+            // (reply == false) [identity, type, sign, pubkey, frames...]
+            int headerCount = reply ? 3 : 4;
+            var type = (MessageType)raw[headerCount - 3].ConvertToInt32();
+            var publicKey = new PublicKey(raw[headerCount - 2].ToByteArray());
+            byte[] signature = raw[headerCount - 1].ToByteArray();
+
+            NetMQFrame[] body = raw.Skip(headerCount).ToArray();
+
+            if (!publicKey.Verify(body.ToByteArray(), signature))
+            {
+                throw new InvalidMessageException("the message signature is invalid");
+            }
+
+            Message message;
+            switch (type)
+            {
+                case MessageType.Ping:
+                    message = new Ping();
+                    break;
+                case MessageType.Pong:
+                    message = new Pong();
+                    break;
+                case MessageType.PeerSetDelta:
+                    message = PeerSetDelta.ParseBody(body);
+                    break;
+                case MessageType.GetBlocks:
+                    message = GetBlocks.ParseBody(body);
+                    break;
+                case MessageType.Inventory:
+                    message = Inventory.Parse(body);
+                    break;
+                default:
+                    throw new InvalidMessageException(
+                        $"Can't determine NetMQMessage. [type: {type}]");
+            }
+
+            if (!reply)
+            {
+                message.Identity = new Address(raw[0].Buffer);
+            }
+
+            return message;
+        }
+
+        public NetMQMessage ToNetMQMessage(PrivateKey key)
+        {
+            var message = new NetMQMessage();
+
+            // Write body (by concrete class)
+            foreach (NetMQFrame frame in DataFrames)
+            {
+                message.Append(frame);
+            }
+
+            // Write headers. (inverse order)
+            message.Push(key.Sign(message.ToByteArray()));
+            message.Push(key.PublicKey.Format(true));
+            message.Push((byte)Type);
+
+            if (Identity is Address to)
+            {
+                message.Push(to.ToByteArray());
+            }
+
+            return message;
+        }
+    }
+}

--- a/Libplanet/Net/Messages/PeerSetDelta.cs
+++ b/Libplanet/Net/Messages/PeerSetDelta.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Libplanet.Crypto;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class PeerSetDelta : Message
+    {
+        public PeerSetDelta(Net.PeerSetDelta peerSetDelta)
+        {
+            Delta = peerSetDelta;
+        }
+
+        public Net.PeerSetDelta Delta { get; }
+
+        protected override MessageType Type =>
+            MessageType.PeerSetDelta;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                using (var stream = new MemoryStream())
+                {
+                    var formatter = new BinaryFormatter();
+                    formatter.Serialize(stream, Delta);
+                    yield return new NetMQFrame(stream.ToArray());
+                }
+            }
+        }
+
+        public static Message ParseBody(NetMQFrame[] frames)
+        {
+            byte[] payload = frames[0].ToByteArray();
+            using (var stream = new MemoryStream(payload))
+            {
+                var formatter = new BinaryFormatter();
+                return new PeerSetDelta(
+                    (Net.PeerSetDelta)formatter.Deserialize(stream));
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Ping.cs
+++ b/Libplanet/Net/Messages/Ping.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class Ping : Message
+    {
+        protected override MessageType Type => MessageType.Ping;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Pong.cs
+++ b/Libplanet/Net/Messages/Pong.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class Pong : Message
+    {
+        protected override MessageType Type => MessageType.Pong;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/Libplanet/Net/NetMQFrameExtension.cs
+++ b/Libplanet/Net/NetMQFrameExtension.cs
@@ -1,0 +1,15 @@
+using System.Security.Cryptography;
+using NetMQ;
+
+namespace Libplanet.Net
+{
+    internal static class NetMQFrameExtension
+    {
+        public static HashDigest<T> ConvertToHashDigest<T>(
+            this NetMQFrame frame)
+            where T : HashAlgorithm
+        {
+            return new HashDigest<T>(frame.ToByteArray());
+        }
+    }
+}

--- a/Libplanet/Net/NetMQFrameExtension.cs
+++ b/Libplanet/Net/NetMQFrameExtension.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.IO;
 using System.Security.Cryptography;
 using NetMQ;
 
@@ -10,6 +12,20 @@ namespace Libplanet.Net
             where T : HashAlgorithm
         {
             return new HashDigest<T>(frame.ToByteArray());
+        }
+
+        public static byte[] ToByteArray(this IEnumerable<NetMQFrame> frames)
+        {
+            using (var stream = new MemoryStream())
+            {
+                foreach (NetMQFrame frame in frames)
+                {
+                    byte[] bytes = frame.ToByteArray();
+                    stream.Write(bytes, 0, bytes.Length);
+                }
+
+                return stream.ToArray();
+            }
         }
     }
 }

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -474,9 +474,10 @@ namespace Libplanet.Net
                         int requestedHashCount = message[2].ConvertToInt32();
                         var locator = new BlockLocator(
                             message.Skip(3).Take(requestedHashCount)
-                            .Select(f => new HashDigest<SHA256>(f.ToByteArray())));
-                        HashDigest<SHA256> stop = new HashDigest<SHA256>(
-                            message.Skip(2 + requestedHashCount).First().ToByteArray());
+                            .Select(f => f.ConvertToHashDigest<SHA256>()));
+                        HashDigest<SHA256> stop = message
+                            .Skip(2 + requestedHashCount).First()
+                            .ConvertToHashDigest<SHA256>();
                         IEnumerable<HashDigest<SHA256>> inventories = blockchain
                             .FindNextHashes(locator, stop, 500);
 


### PR DESCRIPTION
This PR moves message related features (e.g. parsing, signing) from `Swarm` to `Libplanet.Net.Messages`. 

- In this process, I've made `Message` abstract class for more naturally abstracting of `NetMQMessage`, and added a concrete class for each message.
- It also applied the missing message sign/verify to all messages using common code in `Message`.
- Added a missing `stop` parameter to `Swarm.GetBlocksAsync()` in the previous PR(#34).