### PR TITLE
Implement GetData / Block message 

### DIFF
--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -74,7 +74,7 @@ namespace Libplanet.Tests.Blocks
                 0x6e, 0x73, 0x6c, 0x65, 0x65,
             };
 
-            AssertBytesEqual(expected, _fx.Genesis.Bencode(true, true));
+            AssertBytesEqual(expected, _fx.Genesis.ToBencodex(true, true));
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace Libplanet.Tests.Blocks
                 0x30, 0x30, 0x3a, 0x30, 0x30, 0x3a, 0x30, 0x30, 0x2e, 0x30,
                 0x30, 0x30, 0x30, 0x30, 0x30, 0x5a, 0x65, 0x65, 0x65,
             };
-            Block<BaseAction> actual = Block<BaseAction>.FromBencoded(encoded);
+            Block<BaseAction> actual = Block<BaseAction>.FromBencodex(encoded);
             Assert.Equal(_fx.HasTx, actual);
         }
 

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Async;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
@@ -258,7 +259,12 @@ namespace Libplanet.Tests.Net
                         swarmA.AsPeer, new[] { genesis.Hash }, block1.Hash);
                 Assert.Equal(new[] { block1.Hash }, inventories2);
 
-                // TODO Test swarmB.GetData(swarmA.AsPeer, invetories);
+                List<Block<BaseAction>> receivedBlocks =
+                    await swarmB.GetDataAsync<BaseAction>(
+                        swarmA.AsPeer, inventories1
+                    ).ToListAsync();
+
+                Assert.Equal(new[] { block1, block2 }, receivedBlocks);
             }
             finally
             {

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -183,7 +183,7 @@ namespace Libplanet.Tests.Tx
                 0x30, 0x30, 0x30, 0x30, 0x5a, 0x65,
             };
 
-            AssertBytesEqual(expected, _fx.Tx.Bencode(true));
+            AssertBytesEqual(expected, _fx.Tx.ToBencodex(true));
         }
 
         [Fact]
@@ -233,7 +233,7 @@ namespace Libplanet.Tests.Tx
                 0x30, 0x5a, 0x65,
             };
 
-            AssertBytesEqual(expected, _fx.TxWithActions.Bencode(true));
+            AssertBytesEqual(expected, _fx.TxWithActions.ToBencodex(true));
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace Libplanet.Tests.Tx
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
             ).PublicKey;
-            Transaction<BaseAction> tx = Transaction<BaseAction>.FromBencoded(bytes);
+            Transaction<BaseAction> tx = Transaction<BaseAction>.FromBencodex(bytes);
 
             Assert.Equal(publicKey, tx.PublicKey);
             Assert.Equal(new Address(publicKey), tx.Recipient);
@@ -324,7 +324,7 @@ namespace Libplanet.Tests.Tx
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"
                 )
             ).PublicKey;
-            Transaction<BaseAction> tx = Transaction<BaseAction>.FromBencoded(bytes);
+            Transaction<BaseAction> tx = Transaction<BaseAction>.FromBencodex(bytes);
 
             Assert.Equal(publicKey, tx.PublicKey);
             Assert.Equal(new Address(publicKey), tx.Recipient);
@@ -392,7 +392,7 @@ namespace Libplanet.Tests.Tx
         [Fact]
         public void CanDetectBadSignature()
         {
-            Transaction<BaseAction> tx = Transaction<BaseAction>.FromBencoded(
+            Transaction<BaseAction> tx = Transaction<BaseAction>.FromBencodex(
                 ByteUtil.ParseHex(
                     "64373a616374696f6e736c6531303a7075626c69635f6b657936353a0446115b0131baccf94a5856ede871295f6f3d352e6847cda9c03e89fe09f732808711ec97af6e341f110a326da1bdb81f5ae3badf76a90b22c8c491aed3aaa296393a726563697069656e7432303ac2a86014073d662a4a9bfcf9cb54263dfa4f5cbc363a73656e64657232303ac2a86014073d662a4a9bfcf9cb54263dfa4f5cbc393a7369676e617475726537313a3045022100d3009449764f77e5e3de701451f16e6555f0ab7d1fcb1533f1c8977b1af099100220254b158567b4b285d2a31bf3a922596ec8deeffc32e4f2d5e5982f4030478f4d393a74696d657374616d7032373a323031382d31312d32315430303a30303a30302e3030303030305a65"
                 )

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -67,7 +67,7 @@ namespace Libplanet.Blocks
         {
             get
             {
-                byte[] bencoded = Bencode(hash: false, transactionData: true);
+                byte[] bencoded = ToBencodex(hash: false, transactionData: true);
                 return Hashcash.Hash(bencoded);
             }
         }
@@ -111,13 +111,13 @@ namespace Libplanet.Blocks
                 transactions
             );
             Nonce nonce = Hashcash.Answer(
-                n => MakeBlock(n).Bencode(false, true),
+                n => MakeBlock(n).ToBencodex(false, true),
                 difficulty
             );
             return MakeBlock(nonce);
         }
 
-        public static Block<T> FromBencoded(byte[] encoded)
+        public static Block<T> FromBencodex(byte[] encoded)
         {
             var serializer = new BencodexFormatter<Block<T>>();
             using (var stream = new MemoryStream(encoded))
@@ -126,7 +126,7 @@ namespace Libplanet.Blocks
             }
         }
 
-        public byte[] Bencode(bool hash, bool transactionData)
+        public byte[] ToBencodex(bool hash, bool transactionData)
         {
             var serializer = new BencodexFormatter<Block<T>>
             {

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncEnumerator" Version="2.2.1" />
     <PackageReference Include="Bencodex" Version="0.1.0" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
     <PackageReference Include="CommonServiceLocator" Version="1.3.0">

--- a/Libplanet/Net/Messages/Block.cs
+++ b/Libplanet/Net/Messages/Block.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using NetMQ;
+
+namespace Libplanet.Net.Messages
+{
+    internal class Block : Message
+    {
+        public Block(byte[] payload)
+        {
+            Payload = payload;
+        }
+
+        public byte[] Payload { get; }
+
+        protected override MessageType Type => MessageType.Block;
+
+        protected override IEnumerable<NetMQFrame> DataFrames
+        {
+            get
+            {
+                yield return new NetMQFrame(Payload);
+            }
+        }
+
+        internal static Message Parse(NetMQFrame[] body)
+        {
+            return new Block(body.ToByteArray());
+        }
+    }
+}

--- a/Libplanet/Net/Messages/Message.cs
+++ b/Libplanet/Net/Messages/Message.cs
@@ -34,6 +34,16 @@ namespace Libplanet.Net.Messages
             /// Inventory to transfer blocks or txs.
             /// </summary>
             Inventory = 0x05,
+
+            /// <summary>
+            /// Request to query block or tx payload.
+            /// </summary>
+            GetData = 0x06,
+
+            /// <summary>
+            /// Message containing serialized block.
+            /// </summary>
+            Block = 0x07,
         }
 
         public Address? Identity { get; set; }
@@ -80,6 +90,12 @@ namespace Libplanet.Net.Messages
                     break;
                 case MessageType.Inventory:
                     message = Inventory.Parse(body);
+                    break;
+                case MessageType.GetData:
+                    message = GetData.Parse(body);
+                    break;
+                case MessageType.Block:
+                    message = Block.Parse(body);
                     break;
                 default:
                     throw new InvalidMessageException(

--- a/Libplanet/Net/NetMQSocketExtension.cs
+++ b/Libplanet/Net/NetMQSocketExtension.cs
@@ -11,18 +11,8 @@ namespace Libplanet.Net
             this IOutgoingSocket socket,
             byte[] data,
             TimeSpan? timeout = null,
-            TimeSpan? delay = null)
-        {
-            await SendFrameAsync(
-                socket, data, CancellationToken.None, timeout, delay);
-        }
-
-        public static async Task SendFrameAsync(
-            this IOutgoingSocket socket,
-            byte[] data,
-            CancellationToken cancellationToken,
-            TimeSpan? timeout = null,
-            TimeSpan? delay = null)
+            TimeSpan? delay = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             TimeSpan delayNotNull = delay ?? TimeSpan.FromMilliseconds(100);
             TimeSpan elapsed = TimeSpan.Zero;
@@ -44,18 +34,8 @@ namespace Libplanet.Net
             this IOutgoingSocket socket,
             NetMQMessage message,
             TimeSpan? timeout = null,
-            TimeSpan? delay = null)
-        {
-            await SendMultipartMessageAsync(
-                socket, message, CancellationToken.None, timeout, delay);
-        }
-
-        public static async Task SendMultipartMessageAsync(
-            this IOutgoingSocket socket,
-            NetMQMessage message,
-            CancellationToken cancellationToken,
-            TimeSpan? timeout = null,
-            TimeSpan? delay = null)
+            TimeSpan? delay = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             TimeSpan delayNotNull = delay ?? TimeSpan.FromMilliseconds(100);
             TimeSpan elapsed = TimeSpan.Zero;
@@ -76,17 +56,8 @@ namespace Libplanet.Net
         public static async Task<NetMQMessage> ReceiveMultipartMessageAsync(
             this IReceivingSocket socket,
             TimeSpan? timeout = null,
-            TimeSpan? delay = null)
-        {
-            return await ReceiveMultipartMessageAsync(
-                socket, CancellationToken.None, timeout, delay);
-        }
-
-        public static async Task<NetMQMessage> ReceiveMultipartMessageAsync(
-            this IReceivingSocket socket,
-            CancellationToken cancellationToken,
-            TimeSpan? timeout = null,
-            TimeSpan? delay = null)
+            TimeSpan? delay = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             NetMQMessage message = new NetMQMessage();
             TimeSpan delayNotNull = delay ?? TimeSpan.FromMilliseconds(100);

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -357,7 +357,7 @@ namespace Libplanet.Net
                     Message parsedMessage = Message.Parse(response, true);
                     if (parsedMessage is Block blockMessage)
                     {
-                        Block<T> block = Block<T>.FromBencoded(
+                        Block<T> block = Block<T>.FromBencodex(
                             blockMessage.Payload);
                         await yield.ReturnAsync(block);
                         hashCount--;
@@ -481,7 +481,7 @@ namespace Libplanet.Net
             {
                 if (blockchain.Blocks.TryGetValue(hash, out Block<T> block))
                 {
-                    Message response = new Block(block.Bencode(true, true))
+                    Message response = new Block(block.ToBencodex(true, true))
                     {
                         Identity = getData.Identity,
                     };

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -394,7 +394,7 @@ namespace Libplanet.Store
             blockFile.Directory.Create();
             using (Stream stream = blockFile.Open(FileMode.OpenOrCreate, FileAccess.Write))
             {
-                byte[] blockBytes = block.Bencode(true, transactionData: false);
+                byte[] blockBytes = block.ToBencodex(true, transactionData: false);
                 stream.Write(blockBytes, 0, blockBytes.Length);
             }
         }
@@ -405,7 +405,7 @@ namespace Libplanet.Store
             txFile.Directory.Create();
             using (Stream stream = txFile.Open(FileMode.OpenOrCreate, FileAccess.Write))
             {
-                byte[] txBytes = tx.Bencode(true);
+                byte[] txBytes = tx.ToBencodex(true);
                 stream.Write(txBytes, 0, txBytes.Length);
             }
         }

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -86,7 +86,7 @@ namespace Libplanet.Tx
             {
                 using (var hasher = SHA256.Create())
                 {
-                    byte[] payload = Bencode(true);
+                    byte[] payload = ToBencodex(true);
                     return new TxId(hasher.ComputeHash(payload));
                 }
             }
@@ -104,7 +104,7 @@ namespace Libplanet.Tx
 
         public PublicKey PublicKey { get; }
 
-        public static Transaction<T> FromBencoded(byte[] bytes)
+        public static Transaction<T> FromBencodex(byte[] bytes)
         {
             var serializer = new BencodexFormatter<Transaction<T>>();
             using (var stream = new MemoryStream(bytes))
@@ -135,11 +135,11 @@ namespace Libplanet.Tx
                 recipient,
                 timestamp,
                 actions,
-                privateKey.Sign(tx.Bencode(false))
+                privateKey.Sign(tx.ToBencodex(false))
             );
         }
 
-        public byte[] Bencode(bool sign)
+        public byte[] ToBencodex(bool sign)
         {
             var serializer = new BencodexFormatter<Transaction<T>>
             {
@@ -157,7 +157,7 @@ namespace Libplanet.Tx
 
         public void Validate()
         {
-            if (!PublicKey.Verify(Bencode(false), Signature))
+            if (!PublicKey.Verify(ToBencodex(false), Signature))
             {
                 throw new InvalidTxSignatureException(
                     $"the signature ({ByteUtil.Hex(Signature)}) is failed to verify."


### PR DESCRIPTION
This PR implements `GetData` / `Block` message to request and transfer blocks. (it relies [AsyncEnumerator](https://github.com/Dasync/AsyncEnumerable) to create async-generator)

Also it has some other minor changes.

- Renamed bencodex related methods. (see also. https://github.com/planetarium/libplanet.net/pull/46#pullrequestreview-195368085)
- Separated message processing logic from `ReceiveMesseageAsync()` to (new) `ProcessMessageAsync()`
- Replaced `CancellationToken` overload in `Swarm` and `NetMQSocketExtension` with default parameters