### PR TITLE
Pass a context including Random object to IAction.Execute() method

### DIFF
--- a/Libplanet.Tests/Action/ActionContextTest.cs
+++ b/Libplanet.Tests/Action/ActionContextTest.cs
@@ -1,0 +1,24 @@
+using Libplanet.Action;
+using Xunit;
+
+namespace Libplanet.Tests.Action
+{
+    public class ActionContextTest
+    {
+        [Fact]
+        public void RandomShouldBeDeterministic()
+        {
+            (int seed, int expected)[] testCases =
+            {
+                (0, 1559595546),
+                (1, 534011718),
+            };
+            foreach (var (seed, expected) in testCases)
+            {
+                var context = new ActionContext(seed);
+                IRandom random = context.Random;
+                Assert.Equal(expected, random.Next());
+            }
+        }
+    }
+}

--- a/Libplanet.Tests/Common/Action/Attack.cs
+++ b/Libplanet.Tests/Common/Action/Attack.cs
@@ -27,7 +27,11 @@ namespace Libplanet.Tests.Common.Action
             Target = (string)plainValue["target"];
         }
 
-        public override AddressStateMap Execute(Address from, Address to, AddressStateMap states)
+        public override AddressStateMap Execute(
+            Address from,
+            Address to,
+            AddressStateMap states,
+            IActionContext context)
         {
             var result = new BattleResult();
 

--- a/Libplanet.Tests/Common/Action/BaseAction.cs
+++ b/Libplanet.Tests/Common/Action/BaseAction.cs
@@ -8,7 +8,11 @@ namespace Libplanet.Tests.Common.Action
     {
         public abstract IImmutableDictionary<string, object> PlainValue { get; }
 
-        public abstract AddressStateMap Execute(Address from, Address to, AddressStateMap states);
+        public abstract AddressStateMap Execute(
+            Address from,
+            Address to,
+            AddressStateMap states,
+            IActionContext context);
 
         public abstract void LoadPlainValue(IImmutableDictionary<string, object> plainValue);
 

--- a/Libplanet.Tests/Common/Action/DummyAction.cs
+++ b/Libplanet.Tests/Common/Action/DummyAction.cs
@@ -8,7 +8,11 @@ namespace Libplanet.Tests.Common.Action
     {
         public override IImmutableDictionary<string, object> PlainValue => throw new NotImplementedException();
 
-        public override AddressStateMap Execute(Address sender, Address recipient, AddressStateMap requestedStates)
+        public override AddressStateMap Execute(
+            Address sender,
+            Address recipient,
+            AddressStateMap requestedStates,
+            IActionContext context)
         {
             throw new NotImplementedException();
         }

--- a/Libplanet.Tests/Common/Action/Sleep.cs
+++ b/Libplanet.Tests/Common/Action/Sleep.cs
@@ -17,7 +17,11 @@ namespace Libplanet.Tests.Common.Action
                 { "zone_id", ZoneId },
             }.ToImmutableDictionary();
 
-        public override AddressStateMap Execute(Address from, Address to, AddressStateMap states)
+        public override AddressStateMap Execute(
+            Address from,
+            Address to,
+            AddressStateMap states,
+            IActionContext context)
         {
             throw new NotImplementedException();
         }

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -68,7 +68,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
         internal static byte[] GetRandomBytes(int size)
         {
-            var random = new Random();
+            var random = new System.Random();
             var bytes = new byte[size];
             random.NextBytes(bytes);
 

--- a/Libplanet/Action/ActionContext.cs
+++ b/Libplanet/Action/ActionContext.cs
@@ -1,0 +1,12 @@
+namespace Libplanet.Action
+{
+    internal class ActionContext : IActionContext
+    {
+        public ActionContext(int randomSeed)
+        {
+            Random = new Random(randomSeed);
+        }
+
+        public IRandom Random { get; }
+    }
+}

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -11,6 +11,10 @@ namespace Libplanet.Action
 
         ISet<Address> RequestStates(Address from, Address to);
 
-        AddressStateMap Execute(Address from, Address to, AddressStateMap states);
+        AddressStateMap Execute(
+            Address from,
+            Address to,
+            AddressStateMap states,
+            IActionContext context);
     }
 }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,0 +1,7 @@
+namespace Libplanet.Action
+{
+    public interface IActionContext
+    {
+        IRandom Random { get; }
+    }
+}

--- a/Libplanet/Action/IRandom.cs
+++ b/Libplanet/Action/IRandom.cs
@@ -1,0 +1,15 @@
+namespace Libplanet.Action
+{
+    public interface IRandom
+    {
+        int Next();
+
+        int Next(int maxValue);
+
+        int Next(int minValue, int maxValue);
+
+        void NextBytes(byte[] buffer);
+
+        double NextDouble();
+    }
+}

--- a/Libplanet/Action/Random.cs
+++ b/Libplanet/Action/Random.cs
@@ -1,0 +1,10 @@
+namespace Libplanet.Action
+{
+    internal class Random : System.Random, IRandom
+    {
+        public Random(int seed)
+            : base(seed)
+        {
+        }
+    }
+}

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -309,8 +309,10 @@ namespace Libplanet
             HashDigest<SHA256>? prevHash = block.PreviousHash;
             var states = new AddressStateMap();
 
+            int seed = BitConverter.ToInt32(block.Hash.ToByteArray(), 0);
             foreach (Transaction<T> tx in block.Transactions)
             {
+                var context = new ActionContext(randomSeed: unchecked(seed++));
                 foreach (T action in tx.Actions)
                 {
                     IEnumerable<Address> requestedAddresses =
@@ -324,7 +326,7 @@ namespace Libplanet
                         .Where(states.ContainsKey)
                         .ToImmutableDictionary(a => a, a => states[a]));
                     AddressStateMap changes =
-                        action.Execute(tx.Sender, tx.Recipient, prevState);
+                        action.Execute(tx.Sender, tx.Recipient, prevState, context);
                     states = (AddressStateMap)states.SetItems(changes);
                 }
             }


### PR DESCRIPTION
It implements #49.

Context includes Random object.
Seed of Random object is generated using block hash and extra seed.
Extra seed is incremented for each transaction starting at 0.
Thus, each action uses same random seed, but each transaction will use a different random seed.