### PR TITLE
Add Swarm.BroadcastBlocksAsync()

### DIFF
--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Libplanet.Action;
 using Libplanet.Blocks;
@@ -210,6 +211,27 @@ namespace Libplanet.Tests
             _blockchain.DeleteAfter(block2.Hash);
 
             Assert.Equal(new[] { block1, block2 }, _blockchain);
+        }
+
+        [Fact]
+        public void CanGetBlockLocator()
+        {
+            List<Block<BaseAction>> blocks = Enumerable.Range(0, 10)
+                .Select(_ => _blockchain.MineBlock(_fx.Address1))
+                .ToList();
+
+            BlockLocator actual = _blockchain.GetBlockLocator(threshold: 2);
+            BlockLocator expected = new BlockLocator(new[]
+            {
+                blocks[9].Hash,
+                blocks[8].Hash,
+                blocks[7].Hash,
+                blocks[6].Hash,
+                blocks[4].Hash,
+                blocks[0].Hash,
+            });
+
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -183,20 +183,20 @@ namespace Libplanet.Tests
             var block3 = _blockchain.MineBlock(_fx.Address1);
 
             Assert.Equal(
-                new[] { block1.Hash, block2.Hash, block3.Hash, },
+                new[] { block0.Hash, block1.Hash, block2.Hash, block3.Hash, },
                 _blockchain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash })));
             Assert.Equal(
-                new[] { block2.Hash, block3.Hash },
+                new[] { block1.Hash, block2.Hash, block3.Hash },
                 _blockchain.FindNextHashes(
                     new BlockLocator(new[] { block1.Hash, block0.Hash })));
             Assert.Equal(
-                new[] { block1.Hash, block2.Hash },
+                new[] { block0.Hash, block1.Hash, block2.Hash },
                 _blockchain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     stop: block2.Hash));
             Assert.Equal(
-                new[] { block1.Hash, block2.Hash },
+                new[] { block0.Hash, block1.Hash },
                 _blockchain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     count: 2));

--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Threading;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Tests.Common;
 using Libplanet.Tests.Common.Action;
 using Libplanet.Tests.Store;
 using Libplanet.Tx;
@@ -200,6 +198,18 @@ namespace Libplanet.Tests
                 _blockchain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     count: 2));
+        }
+
+        [Fact]
+        public void CanDeleteAfter()
+        {
+            var block1 = _blockchain.MineBlock(_fx.Address1);
+            var block2 = _blockchain.MineBlock(_fx.Address1);
+            var block3 = _blockchain.MineBlock(_fx.Address1);
+
+            _blockchain.DeleteAfter(block2.Hash);
+
+            Assert.Equal(new[] { block1, block2 }, _blockchain);
         }
     }
 }

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Async;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -387,6 +388,79 @@ namespace Libplanet.Tests.Net
 
                 Assert.Equal(tx, chainB.Transactions[tx.Id]);
                 Assert.Equal(tx, chainC.Transactions[tx.Id]);
+            }
+            finally
+            {
+                await Task.WhenAll(
+                    swarmA.DisposeAsync(),
+                    swarmB.DisposeAsync(),
+                    swarmC.DisposeAsync());
+            }
+        }
+
+        [Fact]
+        public async Task CanBroadcastBlock()
+        {
+            Swarm swarmA = _swarms[0];
+            Swarm swarmB = _swarms[1];
+            Swarm swarmC = _swarms[2];
+
+            Blockchain<BaseAction> chainA = _blockchains[0];
+            Blockchain<BaseAction> chainB = _blockchains[1];
+            Blockchain<BaseAction> chainC = _blockchains[2];
+
+            // chainA, chainB and chainC shares genesis block.
+            Block<BaseAction> genesis = chainA.MineBlock(_fx1.Address1);
+            chainB.Append(genesis);
+            chainC.Append(genesis);
+
+            foreach (int i in Enumerable.Range(0, 10))
+            {
+                chainA.MineBlock(_fx1.Address1);
+                await Task.Delay(100);
+            }
+
+            foreach (int i in Enumerable.Range(0, 3))
+            {
+                chainB.MineBlock(_fx2.Address1);
+                await Task.Delay(100);
+            }
+
+            try
+            {
+                await Task.WhenAll(
+                    swarmA.InitContextAsync(),
+                    swarmB.InitContextAsync(),
+                    swarmC.InitContextAsync());
+
+                #pragma warning disable CS4014
+                Task.Run(async () => await swarmA.RunAsync(chainA, 250));
+                Task.Run(async () => await swarmB.RunAsync(chainB, 250));
+                Task.Run(async () => await swarmC.RunAsync(chainC, 250));
+                #pragma warning restore CS4014
+
+                await swarmA.AddPeersAsync(new[] { swarmB.AsPeer });
+                await swarmA.AddPeersAsync(new[] { swarmC.AsPeer });
+
+                await EnsureExchange(swarmA, swarmB);
+                await EnsureExchange(swarmA, swarmC);
+
+                await swarmB.BroadcastBlocksAsync(new[] { chainB.Last() });
+
+                await Task.Delay(5000);
+
+                Assert.Equal(chainB.AsEnumerable(), chainC);
+
+                // chainB doesn't applied to chainA since chainB is shorter
+                // than chainA
+                Assert.NotEqual(chainB.AsEnumerable(), chainA);
+
+                await swarmA.BroadcastBlocksAsync(new[] { chainA.Last() });
+
+                await Task.Delay(5000);
+
+                Assert.Equal(chainA.AsEnumerable(), chainB);
+                Assert.Equal(chainA.AsEnumerable(), chainC);
             }
             finally
             {

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -260,21 +260,27 @@ namespace Libplanet.Tests.Net
                         swarmA.AsPeer,
                         new BlockLocator(new[] { genesis.Hash }),
                         null);
-                Assert.Equal(new[] { block1.Hash, block2.Hash }, inventories1);
+                Assert.Equal(
+                    new[] { genesis.Hash, block1.Hash, block2.Hash },
+                    inventories1);
 
                 IEnumerable<HashDigest<SHA256>> inventories2 =
                     await swarmB.GetBlockHashesAsync(
                         swarmA.AsPeer,
                         new BlockLocator(new[] { genesis.Hash }),
                         block1.Hash);
-                Assert.Equal(new[] { block1.Hash }, inventories2);
+                Assert.Equal(
+                    new[] { genesis.Hash, block1.Hash },
+                    inventories2);
 
                 List<Block<BaseAction>> receivedBlocks =
                     await swarmB.GetBlocksAsync<BaseAction>(
                         swarmA.AsPeer, inventories1
                     ).ToListAsync();
 
-                Assert.Equal(new[] { block1, block2 }, receivedBlocks);
+                Assert.Equal(
+                    new[] { genesis, block1, block2 },
+                    receivedBlocks);
             }
             finally
             {

--- a/Libplanet.Tests/Store/FileStoreTest.cs
+++ b/Libplanet.Tests/Store/FileStoreTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -9,13 +10,13 @@ using Xunit;
 
 namespace Libplanet.Tests.Store
 {
-    public class FileStoreTest : IClassFixture<FileStoreFixture>
+    public class FileStoreTest : IDisposable
     {
         private readonly FileStoreFixture _fx;
 
-        public FileStoreTest(FileStoreFixture fixture)
+        public FileStoreTest()
         {
-            _fx = fixture;
+            _fx = new FileStoreFixture();
         }
 
         [Fact]
@@ -323,6 +324,21 @@ namespace Libplanet.Tests.Store
             AddressStateMap actual = _fx.Store.GetBlockStates(_fx.Hash1);
             Assert.Equal(states[_fx.Address1], actual[_fx.Address1]);
             Assert.Equal(states[_fx.Address2], actual[_fx.Address2]);
+        }
+
+        [Fact]
+        public void CanDeleteIndex()
+        {
+            Assert.False(_fx.Store.DeleteIndex(_fx.Hash1));
+            _fx.Store.AppendIndex(_fx.Hash1);
+            Assert.NotEmpty(_fx.Store.IterateIndex());
+            Assert.True(_fx.Store.DeleteIndex(_fx.Hash1));
+            Assert.Empty(_fx.Store.IterateIndex());
+        }
+
+        public void Dispose()
+        {
+            _fx.Dispose();
         }
     }
 }

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -263,6 +263,20 @@ namespace Libplanet
             }
         }
 
+        internal void DeleteAfter(HashDigest<SHA256> point)
+        {
+            HashDigest<SHA256>? current = Store.IndexBlockHash(-1);
+
+            while (current is HashDigest<SHA256> hash && hash != point)
+            {
+                HashDigest<SHA256>? previous = Blocks[hash].PreviousHash;
+                Store.DeleteBlock(hash);
+                Store.DeleteIndex(hash);
+
+                current = previous;
+            }
+        }
+
         private static IEnumerable<DifficultyExpectation> ExpectDifficulties(
             IEnumerable<Block<T>> blocks, bool yieldNext = false)
         {

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -42,6 +42,8 @@ namespace Libplanet
 
         public IStore Store { get; }
 
+        public Block<T> Tip => this[-1];
+
         public Block<T> this[long index]
         {
             get

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -277,6 +277,34 @@ namespace Libplanet
             }
         }
 
+        internal BlockLocator GetBlockLocator(int threshold = 10)
+        {
+            HashDigest<SHA256>? current = Store.IndexBlockHash(-1);
+            ulong step = 1;
+            var hashes = new List<HashDigest<SHA256>>();
+
+            while (current is HashDigest<SHA256> hash)
+            {
+                hashes.Add(hash);
+                Block<T> currentBlock = Blocks[hash];
+
+                if (currentBlock.Index == 0)
+                {
+                    break;
+                }
+
+                ulong nextIndex = Math.Max(currentBlock.Index - step, 0);
+                current = Store.IndexBlockHash((long)nextIndex);
+
+                if (hashes.Count > threshold)
+                {
+                    step *= 2;
+                }
+            }
+
+            return new BlockLocator(hashes);
+        }
+
         private static IEnumerable<DifficultyExpectation> ExpectDifficulties(
             IEnumerable<Block<T>> blocks, bool yieldNext = false)
         {

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -247,7 +247,7 @@ namespace Libplanet
             }
 
             HashDigest<SHA256>? tip = Store.IndexBlockHash(-1);
-            HashDigest<SHA256>? currentHash = Next(FindBranchPoint(locator));
+            HashDigest<SHA256>? currentHash = FindBranchPoint(locator);
 
             while (currentHash != null && count > 0)
             {

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -71,8 +71,8 @@ namespace Libplanet.Net
             DateTime now = createdAt.GetValueOrDefault(DateTime.UtcNow);
             LastDistributed = now;
             LastReceived = now;
-            DeltaDistributed = new AsyncManualResetEvent();
-            DeltaReceived = new AsyncManualResetEvent();
+            DeltaDistributed = new AsyncAutoResetEvent();
+            DeltaReceived = new AsyncAutoResetEvent();
             TxReceived = new AsyncAutoResetEvent();
 
             _dealers = new Dictionary<Address, DealerSocket>();
@@ -97,10 +97,10 @@ namespace Libplanet.Net
             (_listenUrl != null) ? new[] { _listenUrl } : new Uri[] { });
 
         [Uno.EqualityIgnore]
-        public AsyncManualResetEvent DeltaReceived { get; }
+        public AsyncAutoResetEvent DeltaReceived { get; }
 
         [Uno.EqualityIgnore]
-        public AsyncManualResetEvent DeltaDistributed { get; }
+        public AsyncAutoResetEvent DeltaDistributed { get; }
 
         [Uno.EqualityIgnore]
         public AsyncAutoResetEvent TxReceived { get; }
@@ -730,7 +730,6 @@ namespace Libplanet.Net
 
                 using (await _receiveMutex.LockAsync(cancellationToken))
                 {
-                    DeltaReceived.Reset();
                     _logger.Debug($"Trying to apply the delta[{delta}]...");
                     await ApplyDelta(delta, cancellationToken);
 
@@ -980,7 +979,6 @@ namespace Libplanet.Net
 
                 using (await _distributeMutex.LockAsync(cancellationToken))
                 {
-                    DeltaDistributed.Reset();
                     var message = new Messages.PeerSetDelta(delta);
                     _logger.Debug("Send the delta to dealers...");
 

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -77,5 +77,7 @@ namespace Libplanet.Store
         {
             return IterateAddresses().Count();
         }
+
+        public abstract bool DeleteIndex(HashDigest<SHA256> hash);
     }
 }

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -134,6 +134,31 @@ namespace Libplanet.Store
             }
         }
 
+        public override bool DeleteIndex(HashDigest<SHA256> hash)
+        {
+            bool found = false;
+            using (var writer = new MemoryStream())
+            {
+                foreach (var idx in IterateIndex())
+                {
+                    if (!found && idx == hash)
+                    {
+                        found = true;
+                    }
+                    else
+                    {
+                        writer.Write(
+                            idx.ToByteArray(), 0, HashDigest<SHA256>.Size);
+                    }
+                }
+
+                // FIXME We can't this if the index is too large to buffer...
+                File.WriteAllBytes(_indexPath, writer.ToArray());
+            }
+
+            return found;
+        }
+
         public override ulong CountIndex()
         {
             var indexFile = new FileInfo(_indexPath);

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -16,6 +16,8 @@ namespace Libplanet.Store
 
         long AppendIndex(HashDigest<SHA256> hash);
 
+        bool DeleteIndex(HashDigest<SHA256> hash);
+
         IEnumerable<Address> IterateAddresses();
 
         IEnumerable<TxId> GetAddressTransactionIds(Address address);


### PR DESCRIPTION
This PR implements `Swarm.BroadcastBlocksAsync()` for miner can broadcast mined block to known peers. the following points have also been changed to accomplish it.

- Added `DeleteIndex()` to `IStore` / `FileStore` to able to give up own block indexes when other longest chain appears. 
- Added `Blockchain.DeleteAfter()` to same reason.
- Added `Blockchain.GetBlockLocator()` to query block hashes to broadcasting peer.
- `Blockchain.FindNextHash()` returns result containing branch point.