### PR TITLE
Turn packages only for development into private assets

### DIFF
--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -56,8 +56,11 @@ http://planetarium.github.io/libplanet.net/</Description>
       https://github.com/nventive/Uno/blob/master/doc/articles/faq.md#warning-package-unouisourcegenerationtasks-was-restored-using-netframeworkversion461
       -->
       <NoWarn>NU1701</NoWarn>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3" />
+    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="NetMQ" Version="4.0.0.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
     <PackageReference Include="Serilog" Version="2.7.1" />
@@ -74,6 +77,7 @@ http://planetarium.github.io/libplanet.net/</Description>
       https://github.com/nventive/Uno/blob/master/doc/articles/faq.md#warning-package-unouisourcegenerationtasks-was-restored-using-netframeworkversion461
       -->
       <NoWarn>NU1701</NoWarn>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.CodeGen" Version="1.30.0-dev.102" />
     <PackageReference Include="Uno.Core" Version="1.25.0" />


### PR DESCRIPTION
Since some packages purpose to generate or analyze code, these are unnecessary at runtime.  This patch turns these dependencies into [`<PrivateAssets>`][1].

[1]: https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets