### PR TITLE
API docs for Libplanet.Action namespace

### DIFF
--- a/Libplanet.Tests/Common/Action/BaseAction.cs
+++ b/Libplanet.Tests/Common/Action/BaseAction.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Tests.Common.Action
 
         public abstract void LoadPlainValue(IImmutableDictionary<string, object> plainValue);
 
-        public ISet<Address> RequestStates(Address from, Address to)
+        public IImmutableSet<Address> RequestStates(Address from, Address to)
         {
             return new HashSet<Address> { from, to }.ToImmutableHashSet();
         }

--- a/Libplanet/Action/ActionTypeAttribute.cs
+++ b/Libplanet/Action/ActionTypeAttribute.cs
@@ -4,21 +4,46 @@ using System.Reflection;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// Indicates that an action class (i.e., a class implementing
+    /// <see cref="IAction"/>) can be held by transactions and blocks.
+    /// It also gives an action class a <see cref="TypeIdentifier"/> for
+    /// serialization and deserialization.
+    /// </summary>
     public class ActionTypeAttribute : Attribute
     {
-        private readonly string _value;
-
-        public ActionTypeAttribute(string value)
+        /// <summary>
+        /// Creates an <see cref="ActionTypeAttribute"/> with a given
+        /// <paramref name="typeIdentifier"/>.
+        /// </summary>
+        /// <param name="typeIdentifier">An action class's unique
+        /// identifier for serialization and deserialization.</param>
+        public ActionTypeAttribute(string typeIdentifier)
         {
-            _value = value;
+            TypeIdentifier = typeIdentifier;
         }
 
-        public static string ValueOf(Type t)
+        /// <summary>
+        /// An action class's unique identifier for serialization and
+        /// deserialization.
+        /// </summary>
+        public string TypeIdentifier { get; }
+
+        /// <summary>
+        /// Gets the <see cref="TypeIdentifier"/> for a given action class.
+        /// </summary>
+        /// <param name="actionType">A <see cref="Type"/> object of an action
+        /// class to know its annotated <see cref="TypeIdentifier"/>.</param>
+        /// <returns>The <see cref="TypeIdentifier"/> of the given
+        /// <paramref name="actionType"/> if it's annotated with
+        /// <see cref="ActionTypeAttribute"/>.  If it's not annotated returns
+        /// <c>null</c>.</returns>
+        public static string ValueOf(Type actionType)
         {
-            return t
+            return actionType
                 .GetCustomAttributes()
                 .OfType<ActionTypeAttribute>()
-                .Select(attr => attr._value)
+                .Select(attr => attr.TypeIdentifier)
                 .FirstOrDefault();
         }
     }

--- a/Libplanet/Action/AddressStateMap.cs
+++ b/Libplanet/Action/AddressStateMap.cs
@@ -6,20 +6,37 @@ using System.Runtime.Serialization;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// An immutable key&#x2013;value data structure to represent states of
+    /// multiple accounts.  Keys are an account <see cref="Address"/>,
+    /// and values are their state.
+    /// <para>Since this implements <see
+    /// cref="System.Collections.Immutable.IImmutableDictionary{TKey,TValue}"/>
+    /// interface, the usage is same.</para>
+    /// </summary>
     [Serializable]
     public class AddressStateMap
         : IImmutableDictionary<Address, object>, ISerializable
     {
         private IImmutableDictionary<Address, object> _impl;
 
+        /// <summary>
+        /// Creates an empty map.
+        /// </summary>
         public AddressStateMap()
             : this(new Dictionary<Address, object>().ToImmutableDictionary())
         {
         }
 
-        public AddressStateMap(IImmutableDictionary<Address, object> impl)
+        /// <summary>
+        /// Creates a new map from the items of the
+        /// <paramref name="dictionary"/>.
+        /// </summary>
+        /// <param name="dictionary">A dictionary of items to
+        /// fill the new map with.</param>
+        public AddressStateMap(IImmutableDictionary<Address, object> dictionary)
         {
-            _impl = impl;
+            _impl = dictionary;
         }
 
         protected AddressStateMap(
@@ -37,14 +54,19 @@ namespace Libplanet.Action
             _impl = dict.ToImmutableDictionary();
         }
 
+        /// <inheritdoc />
         public IEnumerable<Address> Keys => _impl.Keys;
 
+        /// <inheritdoc />
         public IEnumerable<object> Values => _impl.Values;
 
+        /// <inheritdoc />
         public int Count => _impl.Count;
 
+        /// <inheritdoc />
         public object this[Address key] => _impl[key];
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> Add(
             Address key,
             object value
@@ -53,6 +75,7 @@ namespace Libplanet.Action
             return new AddressStateMap(_impl.Add(key, value));
         }
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> AddRange(
             IEnumerable<KeyValuePair<Address, object>> pairs
         )
@@ -60,31 +83,37 @@ namespace Libplanet.Action
             return new AddressStateMap(_impl.AddRange(pairs));
         }
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> Clear()
         {
             return new AddressStateMap(_impl.Clear());
         }
 
+        /// <inheritdoc />
         public bool Contains(KeyValuePair<Address, object> pair)
         {
             return _impl.Contains(pair);
         }
 
+        /// <inheritdoc />
         public bool ContainsKey(Address key)
         {
             return _impl.ContainsKey(key);
         }
 
+        /// <inheritdoc />
         public IEnumerator<KeyValuePair<Address, object>> GetEnumerator()
         {
             return _impl.GetEnumerator();
         }
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> Remove(Address key)
         {
             return new AddressStateMap(_impl.Remove(key));
         }
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> RemoveRange(
             IEnumerable<Address> keys
         )
@@ -92,6 +121,7 @@ namespace Libplanet.Action
             return new AddressStateMap(_impl.RemoveRange(keys));
         }
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> SetItem(
             Address key,
             object value
@@ -100,6 +130,7 @@ namespace Libplanet.Action
             return new AddressStateMap(_impl.SetItem(key, value));
         }
 
+        /// <inheritdoc />
         public IImmutableDictionary<Address, object> SetItems(
             IEnumerable<KeyValuePair<Address, object>> items
         )
@@ -107,21 +138,25 @@ namespace Libplanet.Action
             return new AddressStateMap(_impl.SetItems(items));
         }
 
+        /// <inheritdoc />
         public bool TryGetKey(Address equalKey, out Address actualKey)
         {
             return _impl.TryGetKey(equalKey, out actualKey);
         }
 
+        /// <inheritdoc />
         public bool TryGetValue(Address key, out object value)
         {
             return _impl.TryGetValue(key, out value);
         }
 
+        /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _impl.GetEnumerator();
         }
 
+        /// <inheritdoc />
         public void GetObjectData(
             SerializationInfo info,
             StreamingContext context

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -2,14 +2,241 @@ using System.Collections.Immutable;
 
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// An in-game action.  Every action should be replayable, because
+    /// multiple nodes in a network should execute an action and get the same
+    /// result.
+    /// <para>A &#x201c;class&#x201d; which implements this interface is
+    /// analogous to a function, and its instance is analogous to a
+    /// <a href="https://en.wikipedia.org/wiki/Partial_application">partial
+    /// function application</a>, in other words, a function with some bound
+    /// arguments.  Those parameters that will be bound at runtime should be
+    /// represented as fields or properties in an action class, and bound
+    /// argument values to these parameters should be received through
+    /// a constructor parameters of that class.</para>
+    /// <para>By convention, action classes are named with verb phrases, e.g.,
+    /// <c>Heal</c>, <c>Sell</c>.</para>
+    /// </summary>
+    /// <example>
+    /// The following example shows how to implement an action of a character
+    /// healing someone:
+    /// <code><![CDATA[
+    /// using System;
+    /// using System.Collections.Generic;
+    /// using Libplanet.Action;
+    ///
+    /// // Declare the unique identifier of an action type by marking
+    /// // it with ActionTypeAttribute.
+    /// [ActionType("heal")]
+    /// public class Heal : IAction
+    /// {
+    ///     const int RequiredMana = 10;
+    ///     const int HealedHealthMin = 10;
+    ///     const int HealedHealthMAx = 15;
+    ///
+    ///     // Declare properties (or fields) to store "bound" argument values.
+    ///     public CharacterId HealerId { get; private set; }
+    ///     public CharacterId TargetId { get; private set; }
+    ///
+    ///     // Take argument values to "bind" through constructor parameters.
+    ///     public Heal(CharacterId healerId, CharacterId targetId)
+    ///     {
+    ///         HealerId = healerId;
+    ///         TargetId = targetId;
+    ///     }
+    ///
+    ///     public IImmutableSet<Address> RequestStates(Address from,
+    ///                                                 Address to)
+    ///     {
+    ///         // In this action, we need states of two accounts for healing:
+    ///         // - A transaction signer ("from") who holds the healer
+    ///         //   character, and
+    ///         // - A transaction receiver ("to") who hols the healing target
+    ///         //   character.
+    ///         return new HashSet<Address> { from, to }.ToImmutableHashSet();
+    ///     }
+    ///
+    ///     // The main game logic belongs to here.  It takes the
+    ///     // previous states through its parameter named context,
+    ///     // and is offered "bound" argument values through
+    ///     // its own properties (or fields).
+    ///     public AddressStateMap Execute(IActionContext context)
+    ///     {
+    ///         // Gets the states immediately before this action is executed.
+    ///         // The AddressStateMap implemenets IImmutableDictionary<Address,
+    ///         // object> so that you could treat it as a dictionary of account
+    ///         // addresses to their own state.
+    ///         // Note that there are only requested accounts' states.
+    ///         // See also RequestStates() method.
+    ///         AddressStateMap states = context.PreviousStates;
+    ///
+    ///         // Suppose we already declared below in-game objects "Player"
+    ///         // and "Character".  These are immutable (as we highly
+    ///         // recommend) and methods like ".WithFoo(bar)" mean it copies
+    ///         // a game object and set new object's "Foo" property with "bar".
+    ///         Player sender = states[context.From] as Player;
+    ///         if (sender == null)
+    ///             throw new Exception("Sender's player was not made.");
+    ///
+    ///         Character healerPrev = sender.Characters[HealerId];
+    ///         if (healerPrev.Mana < RequiredMana)
+    ///             throw new Exception("The healer doesn't have enough mana.");
+    ///
+    ///         Player receiver = states[context.To] as Player;
+    ///         if (receiver == null)
+    ///             throw new Exception("Receiver's player was not made.");
+    ///
+    ///         // The amount of health to be healed is randomly determined
+    ///         // in a range from 10 to 15 (see HealedHealthMin and
+    ///         // HealedHealthMax).  Note that it does not use System.Random.
+    ///         int healedHealth = context.Random.Next(
+    ///             HealedHealthMin,
+    ///             HealedHealthMax + 1  // As this is exclusive bound, add 1.
+    ///         );
+    ///
+    ///         // Prepares new game objects that represent states after
+    ///         // this action executes.  Note that Character objects are
+    ///         // immutable, so their properties do not have setter but
+    ///         // WithPropName() methods instead.
+    ///         Character targetPrev = receiver.Characters[TargetId];
+    ///         Character healerNext =
+    ///             healerPrev.WithMana(healerPrev.Mana - RequiredMana);
+    ///         Character targetNext = targetPrev.WithHealth(
+    ///             Math.Min(
+    ///                 targetPrev.Health + healedHealth,
+    ///                 targetPrev.MaxHealth
+    ///             )
+    ///         );
+    ///
+    ///         // Builds a delta (diff) from previous to next states, and
+    ///         // returns it as AddressStateMap.
+    ///         var statesDelta = new Dictionary<Address, object>
+    ///         {
+    ///             {context.From, sender.WithCharacters(HealerId, healerNext)},
+    ///             {context.To, receiver.WithCharacters(TargetId, targetNext)},
+    ///         };
+    ///         return new AddressStateMap(statesDelta.ToImmutableDictionary());
+    ///     }
+    ///
+    ///     // Serializes its "bound arguments" so that they are transmitted
+    ///     // over network or stored to the persistent storage.
+    ///     // It uses .NET's built-in serialization mechanism.
+    ///     public IImmutableDictionary<string, object> PlainValue =>
+    ///         new Dictionary<string, object>
+    ///         {
+    ///             {"healer_id", HealerId.ToInt()},
+    ///             {"target_id", TargetId.ToInt()},
+    ///         }
+    ///
+    ///     // Deserializes "bound arguments".  That is, it is inverse
+    ///     // of PlainValue property.
+    ///     public void LoadPlainValue(
+    ///         IImmutableDictionary<string, object> plainValue)
+    ///     {
+    ///         HealerId = CharacterId.FromInt(plainValue["healer_id"] as int);
+    ///         TargetId = CharacterId.FromInt(plainValue["target_id"] as int);
+    ///     }
+    /// }
+    /// ]]></code></example>
+    /// <remarks>Every action class should be marked with the
+    /// <see cref="ActionTypeAttribute"/>.  Even if a superclass is marked
+    /// with the <see cref="ActionTypeAttribute"/> its subclass also should be
+    /// marked with the <see cref="ActionTypeAttribute"/>.</remarks>
     public interface IAction
     {
+        /// <summary>
+        /// Serializes values bound to an action, which is held by properties
+        /// (or fields) of an action, so that they can be transmitted over
+        /// network or saved to persistent storage.
+        /// <para>Serialized values are deserialized by <see
+        /// cref="LoadPlainValue(IImmutableDictionary{string, object})"/> method
+        /// later.</para>
+        /// <para>It uses <a href=
+        /// "https://docs.microsoft.com/en-us/dotnet/standard/serialization/"
+        /// >.NET's built-in serialization mechanism</a>.</para>
+        /// </summary>
+        /// <returns>A value which encodes this action's bound values (held
+        /// by properties or fields).  It has to be <a href=
+        /// "https://docs.microsoft.com/en-us/dotnet/standard/serialization/"
+        /// >serializable</a>.</returns>
+        /// <seealso
+        /// cref="LoadPlainValue(IImmutableDictionary{string, object})"/>
         IImmutableDictionary<string, object> PlainValue { get; }
 
+        /// <summary>
+        /// Deserializes serialized data (i.e., data <see cref="PlainValue"/>
+        /// property made), and then fills this action's properties (or fields)
+        /// with the deserialized values.
+        /// </summary>
+        /// <param name="plainValue">Data (made by <see cref="PlainValue"/>
+        /// property) to be deserialized and assigned to this action's
+        /// properties (or fields).</param>
+        /// <seealso cref="PlainValue"/>
         void LoadPlainValue(IImmutableDictionary<string, object> plainValue);
 
+        /// <summary>
+        /// Declares the set of <see cref="Address"/>es that an action requires
+        /// to fetch states.
+        /// <para>For example, if an action is someone healing someone it needs
+        /// to know a healer's remaning mana (i.e., MP) and a healing target's
+        /// remaining health (i.e., HP).  As a healing character belongs to
+        /// an account who signed the transaction and a healed character belongs
+        /// to an account who will receive the transaction, that healing
+        /// action's <see cref="RequestStates(Address, Address)"/> should
+        /// return a set of <paramref name="from"/> and <paramref name="to"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="from">An <see cref="Address"/> of the account who
+        /// signed the transaction this action belongs to.</param>
+        /// <param name="to">An <see cref="Address"/> of the account who will
+        /// receive the transaction this action belongs to.</param>
+        /// <returns>An immutable set of <see cref="Address"/>es required by
+        /// this action.  Addresses are not limited to only <paramref
+        /// name="from"/> and <paramref name="to"/>.</returns>
+        /// <example>
+        /// The following example shows an action requiring states of
+        /// a transaction sender and a transaction receiver:
+        /// <code><![CDATA[
+        /// public IImmutableSet<Address> RequestStates(Address from,
+        ///                                             Address to)
+        /// {
+        ///     return new HashSet<Address> { from, to }.ToImmutableHashSet();
+        /// }
+        /// ]]></code>
+        /// </example>
         IImmutableSet<Address> RequestStates(Address from, Address to);
 
+        /// <summary>
+        /// Executes the main game logic of an action.  This should be
+        /// <em>deterministic</em>.
+        /// <para>Through the <paramref name="context"/> object,
+        /// it receives information such as a transaction sender and a receiver,
+        /// its states immediately before the execution,
+        /// and a deterministic random seed.</para>
+        /// <para>Other &#x201c;bound&#x201d; information resides in the action
+        /// object in itself, as its properties (or fields).</para>
+        /// <para>A returned <see cref="AddressStateMap"/> object functions as
+        /// a delta which shifts from previous states to next states.</para>
+        /// </summary>
+        /// <param name="context">A context object containing addresses that
+        /// signed and receives the transaction,
+        /// states immediately before the execution,
+        /// and a PRNG object which produces deterministic random numbers.
+        /// See <see cref="IActionContext"/> for details.</param>
+        /// <returns>A map of <see cref="Address"/>es with changed states.
+        /// Only those addresses this map contains will have their states
+        /// updated globally.
+        /// That means, addresses this map misses are unchanged.</returns>
+        /// <remarks>This method should be deterministic:
+        /// for structurally (member-wise) equal actions and <see
+        /// cref="IActionContext"/>s, the same result should be returned.
+        /// <para>For randomness, <em>never</em> use <see cref="System.Random"/>
+        /// nor any other PRNGs provided by other than Libplanet.
+        /// Use <see cref="IActionContext.Random"/> instead.</para>
+        /// <para>Also do not perform I/O operations such as file system access
+        /// or networking.  These bring an action indeterministic.</para>
+        /// </remarks>
+        /// <seealso cref="IActionContext"/>
         AddressStateMap Execute(IActionContext context);
     }
 }

--- a/Libplanet/Action/IAction.cs
+++ b/Libplanet/Action/IAction.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Libplanet.Action
@@ -9,7 +8,7 @@ namespace Libplanet.Action
 
         void LoadPlainValue(IImmutableDictionary<string, object> plainValue);
 
-        ISet<Address> RequestStates(Address from, Address to);
+        IImmutableSet<Address> RequestStates(Address from, Address to);
 
         AddressStateMap Execute(IActionContext context);
     }

--- a/Libplanet/Action/IActionContext.cs
+++ b/Libplanet/Action/IActionContext.cs
@@ -1,13 +1,40 @@
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// Contextual data determined by a transaction and a block.
+    /// Passed to <see cref="IAction.Execute(IActionContext)"/> method.
+    /// </summary>
     public interface IActionContext
     {
+        /// <summary>
+        /// <see cref="Address"/> of an account who made and signed
+        /// a transaction that an executed <see cref="IAction"/> belongs to.
+        /// </summary>
         Address From { get; }
 
+        /// <summary>
+        /// <see cref="Address"/> of an account who receives a transaction that
+        /// an executed <see cref="IAction"/> belongs to.
+        /// </summary>
         Address To { get; }
 
+        /// <summary>
+        /// The state of accounts related to query before <see cref="IAction"/>
+        /// executes.  Those addresses are determined by
+        /// <see cref="IAction.RequestStates(Address, Address)"/> method.
+        /// </summary>
+        /// <seealso cref="IAction.RequestStates(Address, Address)"/>
         AddressStateMap PreviousStates { get; }
 
+        /// <summary>
+        /// An initialized pseudorandom number generator.  Its seed (state)
+        /// is determined by a block and a transaction, which is
+        /// deterministic so that every node can replay the same action and
+        /// then reproduce the same result, while neither a single block miner
+        /// nor a single transaction signer can predict the result and cheat.
+        /// </summary>
+        /// <returns>A random object that shares interface mostly equivalent
+        /// to <see cref="System.Random"/>.</returns>
         IRandom Random { get; }
     }
 }

--- a/Libplanet/Action/IRandom.cs
+++ b/Libplanet/Action/IRandom.cs
@@ -1,15 +1,80 @@
+using System;
+
 namespace Libplanet.Action
 {
+    /// <summary>
+    /// An pseudorandom number generator interface equivalent to
+    /// <see cref="System.Random"/>.
+    /// <para>Although these two types have similar shapes, they are not
+    /// compatible (i.e., disallowed to be casted to each other).</para>
+    /// </summary>
     public interface IRandom
     {
+        /// <summary>
+        /// Gets a non-negative random integer.
+        /// </summary>
+        /// <returns>A 32-bit signed integer that is greater than or equal to
+        /// 0 and less than <see cref="int.MaxValue"/>.</returns>
+        /// <seealso cref="System.Random.Next()"/>
         int Next();
 
+        /// <summary>
+        /// Gets a non-negative random integer that is less than the specified
+        /// <paramref name="maxValue"/>.
+        /// </summary>
+        /// <param name="maxValue">The exclusive upper bound of the random
+        /// number to be generated.  It must be greater than or equal to 0.
+        /// </param>
+        /// <returns>A 32-bit signed integer that is greater than or equal to
+        /// 0 and less than <paramref name="maxValue"/>; that is, the range of
+        /// return values ordinarily includes 0 but not <paramref
+        /// name="maxValue"/>.  However, if <paramref name="maxValue"/> equals
+        /// to 0, <paramref name="maxValue"/> is returned.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when
+        /// <paramref name="maxValue"/> is less than 0.</exception>
+        /// <seealso cref="System.Random.Next(int)"/>
         int Next(int maxValue);
 
+        /// <summary>
+        /// Gets a random integer that is within a specified range.
+        /// </summary>
+        /// <param name="minValue">The inclusive lower bound of the random
+        /// number to be generated.</param>
+        /// <param name="maxValue">The exclusive upper bound of the random
+        /// number to be generated.  It must be greater than or equal to
+        /// <paramref name="minValue"/>.
+        /// </param>
+        /// <returns>A 32-bit signed integer that is greater than or equal to
+        /// <paramref name="minValue"/> and less than <paramref
+        /// name="maxValue"/>; that is, the range of return values ordinarily
+        /// includes <paramref name="minValue"/> but not <paramref
+        /// name="maxValue"/>.  If <paramref name="maxValue"/> equals to
+        /// <paramref name="minValue"/>, <paramref name="minValue"/> is
+        /// returned.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when
+        /// <paramref name="maxValue"/> is less than <paramref
+        /// name="minValue"/>.</exception>
+        /// <seealso cref="System.Random.Next(int, int)"/>
         int Next(int minValue, int maxValue);
 
+        /// <summary>
+        /// Fills the elements of a specified <see cref="byte"/>s <paramref
+        /// name="buffer"/> with random numbers.
+        /// </summary>
+        /// <param name="buffer">A <see cref="byte"/> array to contain random
+        /// numbers.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref
+        /// name="buffer"/> is <c>null</c>.</exception>
+        /// <seealso cref="System.Random.NextBytes(byte[])"/>
         void NextBytes(byte[] buffer);
 
+        /// <summary>
+        /// Gets a random floating-point number that is greater than or
+        /// equal to 0.0, and less than 1.0.
+        /// </summary>
+        /// <returns>A double-precision floating point number that is greater
+        /// than or equal to 0.0, and less than 1.0.</returns>
+        /// <seealso cref="System.Random.NextDouble()"/>
         double NextDouble();
     }
 }


### PR DESCRIPTION
Wrote API docs for `Libplanet.Action` namespace.  It also made the return type of `IAction.RequestStates()` method immutable.

There's some example code as well in docs of `Libplanet.Action.IAction` interface.  Please review carefully that code as well.

Preview: <https://planetarium.github.io/libplanet.net/pulls/63/api/Libplanet.Action.html>