### PR TITLE
Loosen Block.Timestamp constraints (#65)

### DIFF
--- a/Libplanet.Tests/BlockchainTest.cs
+++ b/Libplanet.Tests/BlockchainTest.cs
@@ -48,9 +48,6 @@ namespace Libplanet.Tests
             Block<BaseAction> block = _blockchain.MineBlock(_fx.Address1);
             Assert.Equal(block, _blockchain[0]);
 
-            // To avoid InvalidBlockTimestampException.
-            Thread.Sleep(100);
-
             Block<BaseAction> anotherBlock = _blockchain.MineBlock(_fx.Address2);
             Assert.Equal(anotherBlock, _blockchain[1]);
         }
@@ -174,11 +171,7 @@ namespace Libplanet.Tests
             _blockchain.Append(_fx.Block1);
             var block0 = _fx.Block1;
             var block1 = _blockchain.MineBlock(_fx.Address1);
-
-            Thread.Sleep(1);
             var block2 = _blockchain.MineBlock(_fx.Address1);
-
-            Thread.Sleep(1);
             var block3 = _blockchain.MineBlock(_fx.Address1);
 
             Assert.Equal(

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography;
 using Libplanet.Blocks;
 using Libplanet.Tests.Common.Action;
+using Libplanet.Tx;
 using Xunit;
 using static Libplanet.Tests.TestUtils;
 
@@ -158,6 +159,26 @@ namespace Libplanet.Tests.Blocks
 
             _fx.Genesis.Validate();
             _fx.Next.Validate();
+        }
+
+        [Fact]
+        public void CanDetectInvalidTimestamp()
+        {
+            DateTime now = DateTime.UtcNow;
+            var block = Block<BaseAction>.Mine(
+                _fx.Next.Index,
+                _fx.Next.Difficulty,
+                _fx.Next.RewardBeneficiary.Value,
+                _fx.Genesis.Hash,
+                now + TimeSpan.FromSeconds(901),
+                new Transaction<BaseAction>[] { }
+            );
+
+            Assert.Throws<InvalidBlockTimestampException>(
+                () => { block.Validate(now); });
+
+            // it's okay because 2 seconds later.
+            block.Validate(now + TimeSpan.FromSeconds(2));
         }
 
         [Fact]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -231,11 +231,7 @@ namespace Libplanet.Tests.Net
 
             Block<BaseAction> genesis = chainA.MineBlock(_fx1.Address1);
             chainB.Append(genesis); // chainA and chainB shares genesis block.
-
-            Thread.Sleep(1);
             Block<BaseAction> block1 = chainA.MineBlock(_fx1.Address1);
-
-            Thread.Sleep(1);
             Block<BaseAction> block2 = chainA.MineBlock(_fx1.Address1);
 
             try

--- a/Libplanet/Blockchain.cs
+++ b/Libplanet/Blockchain.cs
@@ -107,15 +107,7 @@ namespace Libplanet
                     );
                 }
 
-                if (now < block.Timestamp)
-                {
-                    throw new InvalidBlockTimestampException(
-                        $"the block #{i}'s timestamp ({block.Timestamp}) is " +
-                        $"later than now ({now})"
-                    );
-                }
-
-                if (block.Timestamp <= prevTimestamp)
+                if (block.Timestamp < prevTimestamp)
                 {
                     throw new InvalidBlockTimestampException(
                         $"the block #{i}'s timestamp ({block.Timestamp}) is " +
@@ -123,7 +115,7 @@ namespace Libplanet
                     );
                 }
 
-                block.Validate();
+                block.Validate(now);
                 prevHash = block.Hash;
                 prevTimestamp = block.Timestamp;
             }

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -18,6 +18,9 @@ namespace Libplanet.Blocks
     {
         internal const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
+        private static readonly TimeSpan TimestampThreshold =
+            TimeSpan.FromSeconds(900);
+
         public Block(
             ulong index,
             uint difficulty,
@@ -147,6 +150,19 @@ namespace Libplanet.Blocks
 
         public void Validate()
         {
+            Validate(DateTime.UtcNow);
+        }
+
+        public void Validate(DateTime now)
+        {
+            if (now + TimestampThreshold < Timestamp)
+            {
+                throw new InvalidBlockTimestampException(
+                    $"The block #{Index}'s timestamp ({Timestamp}) is " +
+                    $"later than now ({now}, threshold: {TimestampThreshold})."
+                );
+            }
+
             if (Index < 0)
             {
                 throw new InvalidBlockIndexException(


### PR DESCRIPTION
It resolves #65. as mentioned in #65, it loosens the `Block.Timestamp`'s constraint [like Ethereum](https://github.com/ethereum/wiki/blob/c02254611f218f43cbb07517ca8e5d00fd6d6d75/Block-Protocol-2.0.md#block-validation-algorithm).

Also, the validation related to the current time has been moved from `Blockchain.Validate()` to `Block.Validate()`.
