### PR TITLE
Simplify swarm interface

### DIFF
--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -95,7 +95,7 @@ namespace Libplanet.Tests.Net
             Blockchain<BaseAction> chain = _blockchains[0];
 
             await swarm.StopAsync();
-            Task t = Task.Run(async () =>
+            Task task = Task.Run(async () =>
             {
                 await swarm.StartAsync(chain, 250);
             });
@@ -105,7 +105,7 @@ namespace Libplanet.Tests.Net
             await swarm.StopAsync();
 
             Assert.False(swarm.Running);
-            await t;
+            await task;
         }
 
         [Fact]
@@ -237,18 +237,12 @@ namespace Libplanet.Tests.Net
             Blockchain<BaseAction> chain = _blockchains[0];
             var cts = new CancellationTokenSource();
 
-            try
-            {
-                var at = Task.Run(
-                    async () => await swarm.StartAsync(chain, 250, cts.Token));
+            Task task = Task.Run(
+                async () => await swarm.StartAsync(chain, 250, cts.Token));
 
-                cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(async () => await at);
-            }
-            finally
-            {
-                await swarm.StopAsync();
-            }
+            cts.Cancel();
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+            Assert.False(swarm.Running);
         }
 
         [Fact]

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -73,6 +72,43 @@ namespace Libplanet.Tests.Net
         }
 
         [Fact]
+        public async Task CanNotStartTwice()
+        {
+            Swarm swarm = _swarms[0];
+            Blockchain<BaseAction> chain = _blockchains[0];
+
+            #pragma warning disable CS4014
+            Task.Run(async () => { await swarm.StartAsync(chain); });
+            #pragma warning restore CS4014
+
+            await Assert.ThrowsAsync<SwarmException>(async () =>
+            {
+                await swarm.StartAsync(chain);
+            });
+            await swarm.StopAsync();
+        }
+
+        [Fact]
+        public async Task CanStop()
+        {
+            Swarm swarm = _swarms[0];
+            Blockchain<BaseAction> chain = _blockchains[0];
+
+            await swarm.StopAsync();
+            Task t = Task.Run(async () =>
+            {
+                await swarm.StartAsync(chain, 250);
+            });
+
+            await Task.Delay(500);
+            Assert.True(swarm.Running);
+            await swarm.StopAsync();
+
+            Assert.False(swarm.Running);
+            await t;
+        }
+
+        [Fact]
         public async Task WorksAsExpected()
         {
             Swarm a = _swarms[0];
@@ -86,22 +122,18 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await b.InitContextAsync();
-                await c.InitContextAsync();
-
                 try
                 {
-                    await a.InitContextAsync();
+                    var at = Task.Run(async () => await a.StartAsync(chain, 250));
+                    var bt = Task.Run(async () => await b.StartAsync(chain, 250));
+                    var ct = Task.Run(async () => await c.StartAsync(chain, 250));
 
-                    var at = Task.Run(async () => await a.RunAsync(chain, 250));
                     await b.AddPeersAsync(new[] { a.AsPeer });
-                    var bt = Task.Run(async () => await b.RunAsync(chain, 250));
                     await EnsureExchange(a, b);
                     Assert.Equal(new[] { b.AsPeer }.ToImmutableHashSet(), a.ToImmutableHashSet());
                     Assert.Equal(new[] { a.AsPeer }.ToImmutableHashSet(), b.ToImmutableHashSet());
 
                     await c.AddPeersAsync(new[] { a.AsPeer });
-                    var ct = Task.Run(async () => await c.RunAsync(chain, 250));
                     await EnsureExchange(a, c);
                     await EnsureExchange(a, b);
 
@@ -114,7 +146,7 @@ namespace Libplanet.Tests.Net
                 }
                 finally
                 {
-                    await a.DisposeAsync();
+                    await a.StopAsync();
                 }
 
                 Assert.True(lastDistA < a.LastDistributed);
@@ -128,8 +160,8 @@ namespace Libplanet.Tests.Net
             }
             finally
             {
-                await b.DisposeAsync();
-                await c.DisposeAsync();
+                await b.StopAsync();
+                await c.StopAsync();
             }
         }
 
@@ -207,16 +239,15 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await swarm.InitContextAsync();
                 var at = Task.Run(
-                    async () => await swarm.RunAsync(chain, 250, cts.Token));
+                    async () => await swarm.StartAsync(chain, 250, cts.Token));
 
                 cts.Cancel();
                 await Assert.ThrowsAsync<TaskCanceledException>(async () => await at);
             }
             finally
             {
-                await swarm.DisposeAsync();
+                await swarm.StopAsync();
             }
         }
 
@@ -236,13 +267,10 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await Task.WhenAll(
-                    swarmA.InitContextAsync(),
-                    swarmB.InitContextAsync());
                 var at = Task.Run(
-                    async () => await swarmA.RunAsync(chainA, 250));
+                    async () => await swarmA.StartAsync(chainA, 250));
                 var bt = Task.Run(
-                    async () => await swarmB.RunAsync(chainB, 250));
+                    async () => await swarmB.StartAsync(chainB, 250));
 
                 await Assert.ThrowsAsync<PeerNotFoundException>(
                     async () => await swarmB.GetBlockHashesAsync(
@@ -282,8 +310,8 @@ namespace Libplanet.Tests.Net
             finally
             {
                 await Task.WhenAll(
-                    swarmA.DisposeAsync(),
-                    swarmB.DisposeAsync());
+                    swarmA.StopAsync(),
+                    swarmB.StopAsync());
             }
         }
 
@@ -307,13 +335,9 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await Task.WhenAll(
-                    swarmA.InitContextAsync(),
-                    swarmB.InitContextAsync());
-
                 #pragma warning disable CS4014
-                Task.Run(async () => await swarmA.RunAsync(chainA, 250));
-                Task.Run(async () => await swarmB.RunAsync(chainB, 250));
+                Task.Run(async () => await swarmA.StartAsync(chainA, 250));
+                Task.Run(async () => await swarmB.StartAsync(chainB, 250));
                 #pragma warning restore CS4014
 
                 Assert.Throws<PeerNotFoundException>(
@@ -332,8 +356,8 @@ namespace Libplanet.Tests.Net
             finally
             {
                 await Task.WhenAll(
-                    swarmA.DisposeAsync(),
-                    swarmB.DisposeAsync());
+                    swarmA.StopAsync(),
+                    swarmB.StopAsync());
             }
         }
 
@@ -360,15 +384,10 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await Task.WhenAll(
-                    swarmA.InitContextAsync(),
-                    swarmB.InitContextAsync(),
-                    swarmC.InitContextAsync());
-
                 #pragma warning disable CS4014
-                Task.Run(async () => await swarmA.RunAsync(chainA, 250));
-                Task.Run(async () => await swarmB.RunAsync(chainB, 250));
-                Task.Run(async () => await swarmC.RunAsync(chainC, 250));
+                Task.Run(async () => await swarmA.StartAsync(chainA, 250));
+                Task.Run(async () => await swarmB.StartAsync(chainB, 250));
+                Task.Run(async () => await swarmC.StartAsync(chainC, 250));
                 #pragma warning restore CS4014
 
                 await swarmA.AddPeersAsync(new[] { swarmB.AsPeer });
@@ -388,9 +407,9 @@ namespace Libplanet.Tests.Net
             finally
             {
                 await Task.WhenAll(
-                    swarmA.DisposeAsync(),
-                    swarmB.DisposeAsync(),
-                    swarmC.DisposeAsync());
+                    swarmA.StopAsync(),
+                    swarmB.StopAsync(),
+                    swarmC.StopAsync());
             }
         }
 
@@ -424,15 +443,10 @@ namespace Libplanet.Tests.Net
 
             try
             {
-                await Task.WhenAll(
-                    swarmA.InitContextAsync(),
-                    swarmB.InitContextAsync(),
-                    swarmC.InitContextAsync());
-
                 #pragma warning disable CS4014
-                Task.Run(async () => await swarmA.RunAsync(chainA, 250));
-                Task.Run(async () => await swarmB.RunAsync(chainB, 250));
-                Task.Run(async () => await swarmC.RunAsync(chainC, 250));
+                Task.Run(async () => await swarmA.StartAsync(chainA, 250));
+                Task.Run(async () => await swarmB.StartAsync(chainB, 250));
+                Task.Run(async () => await swarmC.StartAsync(chainC, 250));
                 #pragma warning restore CS4014
 
                 await swarmA.AddPeersAsync(new[] { swarmB.AsPeer });
@@ -461,9 +475,9 @@ namespace Libplanet.Tests.Net
             finally
             {
                 await Task.WhenAll(
-                    swarmA.DisposeAsync(),
-                    swarmB.DisposeAsync(),
-                    swarmC.DisposeAsync());
+                    swarmA.StopAsync(),
+                    swarmB.StopAsync(),
+                    swarmC.StopAsync());
             }
         }
 

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -42,7 +42,7 @@ namespace Libplanet.Net
         public Swarm(
             PrivateKey privateKey,
             Uri listenUrl,
-            int millisecondsDialTimeout = 15000,
+            int millisecondsDialTimeout,
             DateTime? createdAt = null)
             : this(
                   privateKey,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -282,7 +282,20 @@ namespace Libplanet.Net
 
         public async Task StartAsync<T>(
             Blockchain<T> blockchain,
-            int distributeInterval,
+            int millisecondsDistributeInterval = 1500,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where T : IAction
+        {
+            await StartAsync(
+                blockchain,
+                TimeSpan.FromMilliseconds(millisecondsDistributeInterval),
+                cancellationToken
+            );
+        }
+
+        public async Task StartAsync<T>(
+            Blockchain<T> blockchain,
+            TimeSpan distributeInterval,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : IAction
         {
@@ -1126,7 +1139,7 @@ namespace Libplanet.Net
         }
 
         private async Task RepeatDeltaDistributionAsync(
-            int interval, CancellationToken cancellationToken)
+            TimeSpan interval, CancellationToken cancellationToken)
         {
             int i = 1;
             while (Running)


### PR DESCRIPTION
This PR simplifies `Swarm`'s interface as #69. specifically, the following changes have been made.

- Renamed `RunAsync()` / `DisposeAsync()` to `StartAsync()` / `StopAsync()`
- Integrated `InitContextAsync()` into `RunAsync()`
- Removed `_delta` queue and replace related logic with worker task.
- Resolved ambiguous constructor overloading.
- Made interval in StartAsync() to optional