### PR TITLE
Code coverage

### DIFF
--- a/.travis.dotCover.xml
+++ b/.travis.dotCover.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Configuration for dotCover.  It is intended to be used when
+Travis CI executes dotCover.  $ASSEMBLY is a placeholder
+to be replaced using sed. -->
+<CoverageParams>
+  <TargetExecutable>C:\ProgramData\chocolatey\bin\xunit.console.exe</TargetExecutable>
+  <TargetArguments>$ASSEMBLY -diagnostics</TargetArguments>
+  <TargetWorkingDir></TargetWorkingDir>
+  <ReportType>DetailedXML</ReportType>
+  <Output>$ASSEMBLY.cov.xml</Output>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Libplanet</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+    <ExcludeFilters>
+      <FilterEntry>
+        <ModuleMask>Libplanet.Tests</ModuleMask>
+      </FilterEntry>
+    </ExcludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+</CoverageParams>

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,22 @@ install:
     done
     mv */*.exe */*.dll /c/Windows/
     popd
+
+    # Tools for test coverage (dotcover-clt, codecov-exe, xunit)
+    if [[ "$CODECOV_TOKEN" != "" ]]; then
+      mkdir /tmp/dotcover
+      pushd /tmp
+      wget \
+        https://download.jetbrains.com/resharper/ReSharperUltimate.2018.3.3/JetBrains.dotCover.CommandLineTools.2018.3.3.zip
+      pushd dotcover
+      7z x ../JetBrains.dotCover.CommandLineTools.*.zip
+      popd
+      mv dotcover/* /c/Windows/
+      rm JetBrains.dotCover.CommandLineTools.*.zip
+      popd
+
+      choco install codecov xunit
+    fi
   fi
   set +ev
 - nuget restore Libplanet.sln
@@ -132,6 +148,23 @@ script:
 
 # Run unit tests
 - msbuild /p:Configuration=Release /t:XunitTest Libplanet.Tests
+
+# Run unit tests with coverage report
+- cat codecov.yml | curl --data-binary @- https://codecov.io/validate
+- |
+  if [[ "$TRAVIS_OS_NAME" = "windows" && "$CODECOV_TOKEN" != "" ]]; then
+    msbuild /p:Configuration=Debug /p:DebugType=full /p:DebugSymbols:true /r
+    for assembly in Libplanet.Tests/bin/Debug/*/Libplanet.Tests.dll; do
+      echo "$assembly:"
+      dotCover_config="$(cat .travis.dotCover.xml)"
+      assembly_abspath="$(cygpath -w "$(pwd)/$assembly")"
+      echo "${dotCover_config//\$ASSEMBLY/$assembly_abspath}" \
+        > "$assembly.dotCover.xml"
+      dotCover.exe cover "$assembly.dotCover.xml"
+      # Upload report to Codecov.io
+      codecov.exe -f "$assembly.cov.xml" -t "$CODECOV_TOKEN"
+    done
+  fi
 
 # Build Libplanet.*.nupkg
 - |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Libplanet
 =========
 
 [![Build Status](https://travis-ci.com/planetarium/libplanet.net.svg?branch=master)][Travis CI]
+[![Codecov](https://codecov.io/gh/planetarium/libplanet.net/branch/master/graph/badge.svg)][Codecov]
 [![NuGet](https://img.shields.io/nuget/v/Libplanet.svg?style=flat)][NuGet]
 [![NuGet (prerelease)](https://img.shields.io/nuget/vpre/Libplanet.svg?style=flat)][NuGet]
 
@@ -12,6 +13,7 @@ server.  Under the hood, it incorporates many features (e.g.,
 [digital signature], [BFT] consensus, data replication) of a [blockchain].
 
 [Travis CI]: https://travis-ci.com/planetarium/libplanet.net
+[Codecov]: https://codecov.io/gh/planetarium/libplanet.net
 [NuGet]: https://www.nuget.org/packages/Libplanet/
 [digital signature]: https://en.wikipedia.org/wiki/Digital_signature
 [BFT]: https://en.wikipedia.org/wiki/Byzantine_fault_tolerance

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  range: 70..95
+  status:
+    project:
+      default:
+        target: auto
+        threshold: "1"
+        base: auto
+
+comment:
+  require_changes: true
+  layout: "diff, files"

--- a/publish.sh
+++ b/publish.sh
@@ -12,6 +12,12 @@ if [[ "$TRAVIS_JOB_NUMBER" != *.1 ]]; then
   exit 0
 fi
 
+if [[ "$NUGET_API_KEY" = "" ]]; then
+  echo "This script is skipped if NUGET_API_KEY envrionment variable is not" \
+       "present." > /dev/stderr
+  exit 0
+fi
+
 set -ev
 
 curl -o /tmp/nuget.exe \


### PR DESCRIPTION
This patch makes Travis CI to measure code coverage of the test suite.  It uses JetBrains' [dotCover] for instrumentation and [Codecov] for visual reports.  Codecov also leaves a comment if a pull request drops or raises code coverage.

[![Codecov](https://codecov.io/gh/planetarium/libplanet.net/branch/master/graph/badge.svg)][Codecov]

[dotCover]: https://www.jetbrains.com/dotcover/
[Codecov]: https://codecov.io/gh/planetarium/libplanet.net