### PR TITLE
Make intervals between blocks configurable

### DIFF
--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -27,7 +27,8 @@ namespace Libplanet.Explorer.Controllers
 
         public BlockChain<T> GetBlockChain()
         {
-            var chain = new BlockChain<T>(Store.Store);
+            // FIXME: policy should be configurable
+            var chain = new BlockChain<T>(new BlockPolicy<T>(), Store.Store);
 
             return chain;
         }

--- a/Libplanet.Explorer/Controllers/ExplorerController.cs
+++ b/Libplanet.Explorer/Controllers/ExplorerController.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.ViewModels;
@@ -23,9 +25,9 @@ namespace Libplanet.Explorer.Controllers
             Store = store;
         }
 
-        public Blockchain<T> GetBlockchain()
+        public BlockChain<T> GetBlockChain()
         {
-            var chain = new Blockchain<T>(Store.Store);
+            var chain = new BlockChain<T>(Store.Store);
 
             return chain;
         }
@@ -33,7 +35,7 @@ namespace Libplanet.Explorer.Controllers
         [HttpGet("/blocks/")]
         public List<Dictionary<string, string>> Index()
         {
-            Blockchain<T> chain = GetBlockchain();
+            BlockChain<T> chain = GetBlockChain();
 
             return chain.Select(block => new Dictionary<string, string>
                 {
@@ -48,7 +50,7 @@ namespace Libplanet.Explorer.Controllers
         {
             Block<T> block;
             HashDigest<SHA256> blockHash;
-            Blockchain<T> chain = GetBlockchain();
+            BlockChain<T> chain = GetBlockChain();
 
             try
             {
@@ -98,7 +100,7 @@ namespace Libplanet.Explorer.Controllers
         {
             Transaction<T> tx;
             TxId txId;
-            Blockchain<T> chain = GetBlockchain();
+            BlockChain<T> chain = GetBlockChain();
 
             try
             {
@@ -153,7 +155,7 @@ namespace Libplanet.Explorer.Controllers
         {
             Address address;
             IEnumerable<Transaction<T>> txs;
-            Blockchain<T> chain = GetBlockchain();
+            BlockChain<T> chain = GetBlockChain();
 
             try
             {

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Action;
 using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
@@ -20,7 +21,10 @@ namespace Libplanet.Tests.Blockchain
         public BlockChainTest()
         {
             _fx = new FileStoreFixture();
-            _blockChain = new BlockChain<BaseAction>(_fx.Store);
+            _blockChain = new BlockChain<BaseAction>(
+                new BlockPolicy<BaseAction>(),
+                _fx.Store
+            );
         }
 
         public void Dispose()

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Libplanet.Action;
+using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Tests.Common.Action;
@@ -10,17 +10,17 @@ using Libplanet.Tests.Store;
 using Libplanet.Tx;
 using Xunit;
 
-namespace Libplanet.Tests
+namespace Libplanet.Tests.Blockchain
 {
-    public class BlockchainTest : IDisposable
+    public class BlockChainTest : IDisposable
     {
         private FileStoreFixture _fx;
-        private Blockchain<BaseAction> _blockchain;
+        private BlockChain<BaseAction> _blockChain;
 
-        public BlockchainTest()
+        public BlockChainTest()
         {
             _fx = new FileStoreFixture();
-            _blockchain = new Blockchain<BaseAction>(_fx.Store);
+            _blockChain = new BlockChain<BaseAction>(_fx.Store);
         }
 
         public void Dispose()
@@ -31,49 +31,49 @@ namespace Libplanet.Tests
         [Fact]
         public void CanMineBlock()
         {
-            Block<BaseAction> block = _blockchain.MineBlock(_fx.Address1);
+            Block<BaseAction> block = _blockChain.MineBlock(_fx.Address1);
             block.Validate();
-            Assert.Contains(block, _blockchain);
+            Assert.Contains(block, _blockChain);
 
-            Block<BaseAction> anotherBlock = _blockchain.MineBlock(_fx.Address2);
+            Block<BaseAction> anotherBlock = _blockChain.MineBlock(_fx.Address2);
             anotherBlock.Validate();
-            Assert.Contains(anotherBlock, _blockchain);
+            Assert.Contains(anotherBlock, _blockChain);
         }
 
         [Fact]
         public void CanFindBlockByIndex()
         {
             // use assignment to snooze compiler error (CS0201)
-            Assert.Throws<IndexOutOfRangeException>(() => { var x = _blockchain[0]; });
-            Block<BaseAction> block = _blockchain.MineBlock(_fx.Address1);
-            Assert.Equal(block, _blockchain[0]);
+            Assert.Throws<IndexOutOfRangeException>(() => { var x = _blockChain[0]; });
+            Block<BaseAction> block = _blockChain.MineBlock(_fx.Address1);
+            Assert.Equal(block, _blockChain[0]);
 
-            Block<BaseAction> anotherBlock = _blockchain.MineBlock(_fx.Address2);
-            Assert.Equal(anotherBlock, _blockchain[1]);
+            Block<BaseAction> anotherBlock = _blockChain.MineBlock(_fx.Address2);
+            Assert.Equal(anotherBlock, _blockChain[1]);
         }
 
         [Fact]
         public void CanIterate()
         {
-            Assert.Empty(_blockchain);
-            _blockchain.MineBlock(_fx.Address1);
+            Assert.Empty(_blockChain);
+            _blockChain.MineBlock(_fx.Address1);
 
-            Assert.NotEmpty(_blockchain);
+            Assert.NotEmpty(_blockChain);
         }
 
         [Fact]
         public void CanStateTransactions()
         {
-            Assert.Empty(_blockchain.Transactions);
+            Assert.Empty(_blockChain.Transactions);
             var txs = new HashSet<Transaction<BaseAction>>()
             {
                 _fx.Transaction1,
                 _fx.Transaction2,
             };
-            _blockchain.StageTransactions(txs);
+            _blockChain.StageTransactions(txs);
             Assert.Equal(
                 txs,
-                _blockchain.Transactions.Values.ToHashSet()
+                _blockChain.Transactions.Values.ToHashSet()
             );
         }
 
@@ -105,10 +105,10 @@ namespace Libplanet.Tests
                 DateTime.UtcNow
             );
 
-            _blockchain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx1 });
-            _blockchain.MineBlock(_fx.Address1);
+            _blockChain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx1 });
+            _blockChain.MineBlock(_fx.Address1);
 
-            AddressStateMap states = _blockchain.GetStates(new List<Address> { _fx.Address1 });
+            AddressStateMap states = _blockChain.GetStates(new List<Address> { _fx.Address1 });
             Assert.NotEmpty(states);
 
             var result = (BattleResult)states[_fx.Address1];
@@ -132,10 +132,10 @@ namespace Libplanet.Tests
                 DateTime.UtcNow
             );
 
-            _blockchain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx2 });
-            _blockchain.MineBlock(_fx.Address1);
+            _blockChain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx2 });
+            _blockChain.MineBlock(_fx.Address1);
 
-            states = _blockchain.GetStates(new List<Address> { _fx.Address1 });
+            states = _blockChain.GetStates(new List<Address> { _fx.Address1 });
             result = (BattleResult)states[_fx.Address1];
             Assert.Contains("bow", result.UsedWeapons);
         }
@@ -143,53 +143,53 @@ namespace Libplanet.Tests
         [Fact]
         public void CanAppendBlock()
         {
-            Assert.Empty(_blockchain.Blocks);
-            _blockchain.Append(_fx.Block1);
-            Assert.Contains(_fx.Block1, _blockchain);
+            Assert.Empty(_blockChain.Blocks);
+            _blockChain.Append(_fx.Block1);
+            Assert.Contains(_fx.Block1, _blockChain);
         }
 
         [Fact]
         public void CanStoreAddresses()
         {
-            Assert.Empty(_blockchain.Addresses);
+            Assert.Empty(_blockChain.Addresses);
             var txs = new HashSet<Transaction<BaseAction>>()
             {
                 _fx.Transaction1,
                 _fx.Transaction2,
             };
-            _blockchain.StageTransactions(txs);
-            _blockchain.MineBlock(_fx.Address1);
+            _blockChain.StageTransactions(txs);
+            _blockChain.MineBlock(_fx.Address1);
 
-            Assert.NotEmpty(_blockchain.Addresses);
-            Assert.Contains(_fx.Transaction1, _blockchain.Addresses[_fx.Transaction1.Recipient]);
-            Assert.DoesNotContain(_fx.Transaction2, _blockchain.Addresses[_fx.Transaction1.Recipient]);
+            Assert.NotEmpty(_blockChain.Addresses);
+            Assert.Contains(_fx.Transaction1, _blockChain.Addresses[_fx.Transaction1.Recipient]);
+            Assert.DoesNotContain(_fx.Transaction2, _blockChain.Addresses[_fx.Transaction1.Recipient]);
         }
 
         [Fact]
         public void CanFindNextHashes()
         {
-            _blockchain.Append(_fx.Block1);
+            _blockChain.Append(_fx.Block1);
             var block0 = _fx.Block1;
-            var block1 = _blockchain.MineBlock(_fx.Address1);
-            var block2 = _blockchain.MineBlock(_fx.Address1);
-            var block3 = _blockchain.MineBlock(_fx.Address1);
+            var block1 = _blockChain.MineBlock(_fx.Address1);
+            var block2 = _blockChain.MineBlock(_fx.Address1);
+            var block3 = _blockChain.MineBlock(_fx.Address1);
 
             Assert.Equal(
                 new[] { block0.Hash, block1.Hash, block2.Hash, block3.Hash, },
-                _blockchain.FindNextHashes(
+                _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash })));
             Assert.Equal(
                 new[] { block1.Hash, block2.Hash, block3.Hash },
-                _blockchain.FindNextHashes(
+                _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block1.Hash, block0.Hash })));
             Assert.Equal(
                 new[] { block0.Hash, block1.Hash, block2.Hash },
-                _blockchain.FindNextHashes(
+                _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     stop: block2.Hash));
             Assert.Equal(
                 new[] { block0.Hash, block1.Hash },
-                _blockchain.FindNextHashes(
+                _blockChain.FindNextHashes(
                     new BlockLocator(new[] { block0.Hash }),
                     count: 2));
         }
@@ -197,23 +197,23 @@ namespace Libplanet.Tests
         [Fact]
         public void CanDeleteAfter()
         {
-            var block1 = _blockchain.MineBlock(_fx.Address1);
-            var block2 = _blockchain.MineBlock(_fx.Address1);
-            var block3 = _blockchain.MineBlock(_fx.Address1);
+            var block1 = _blockChain.MineBlock(_fx.Address1);
+            var block2 = _blockChain.MineBlock(_fx.Address1);
+            var block3 = _blockChain.MineBlock(_fx.Address1);
 
-            _blockchain.DeleteAfter(block2.Hash);
+            _blockChain.DeleteAfter(block2.Hash);
 
-            Assert.Equal(new[] { block1, block2 }, _blockchain);
+            Assert.Equal(new[] { block1, block2 }, _blockChain);
         }
 
         [Fact]
         public void CanGetBlockLocator()
         {
             List<Block<BaseAction>> blocks = Enumerable.Range(0, 10)
-                .Select(_ => _blockchain.MineBlock(_fx.Address1))
+                .Select(_ => _blockChain.MineBlock(_fx.Address1))
                 .ToList();
 
-            BlockLocator actual = _blockchain.GetBlockLocator(threshold: 2);
+            BlockLocator actual = _blockChain.GetBlockLocator(threshold: 2);
             BlockLocator expected = new BlockLocator(new[]
             {
                 blocks[9].Hash,

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -43,6 +43,13 @@ namespace Libplanet.Tests.Blockchain.Policies
                 new TimeSpan(0, 0, 5),
                 c.BlockInterval
             );
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new BlockPolicy<BaseAction>(tenSec.Negate())
+            );
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new BlockPolicy<BaseAction>(-5)
+            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Tests.Common.Action;
+using Libplanet.Tests.Store;
+using Libplanet.Tx;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Blockchain.Policies
+{
+    public class BlockPolicyTest : IClassFixture<FileStoreFixture>
+    {
+        private static readonly DateTime FixtureEpoch =
+            new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        private readonly ITestOutputHelper _output;
+
+        public BlockPolicyTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Constructors()
+        {
+            var tenSec = new TimeSpan(0, 0, 10);
+            var a = new BlockPolicy<BaseAction>(tenSec);
+            Assert.Equal(tenSec, a.BlockInterval);
+
+            var b = new BlockPolicy<BaseAction>(65);
+            Assert.Equal(
+                new TimeSpan(0, 1, 5),
+                b.BlockInterval
+            );
+
+            var c = new BlockPolicy<BaseAction>();
+            Assert.Equal(
+                new TimeSpan(0, 0, 5),
+                c.BlockInterval
+            );
+        }
+
+        [Fact]
+        public void GetNextBlockDifficulty()
+        {
+            var policy = new BlockPolicy<BaseAction>(new TimeSpan(3, 0, 0));
+            Block<BaseAction>[] blocks = MineBlocks(
+                new[] { (0, 0U), (1, 1U), (3, 2U), (7, 3U), (9, 2U), (13, 3U) }
+            ).ToArray();
+
+            Assert.Equal(
+                0U,
+                policy.GetNextBlockDifficulty(blocks.Take(0))
+            );
+            Assert.Equal(
+                1U,
+                policy.GetNextBlockDifficulty(blocks.Take(1))
+            );
+            Assert.Equal(
+                2U,
+                policy.GetNextBlockDifficulty(blocks.Take(2))
+            );
+            Assert.Equal(
+                3U,
+                policy.GetNextBlockDifficulty(blocks.Take(3))
+            );
+            Assert.Equal(
+                2U,
+                policy.GetNextBlockDifficulty(blocks.Take(4))
+            );
+            Assert.Equal(
+                3U,
+                policy.GetNextBlockDifficulty(blocks.Take(5))
+            );
+            Assert.Equal(
+                2U,
+                policy.GetNextBlockDifficulty(blocks)
+            );
+        }
+
+        [Fact]
+        public void ValidateBlocks()
+        {
+            var policy = new BlockPolicy<BaseAction>(new TimeSpan(3, 0, 0));
+
+            // The genesis block must has the index #0.
+            Assert.IsType<InvalidBlockIndexException>(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U) },
+                        fields =>
+                        {
+                            fields.Index = 1UL;
+                            return fields;
+                        }
+                    ),
+                    FixtureEpoch + new TimeSpan(0, 1, 0)
+                )
+            );
+
+            // The genesis block must not have PreviousHash
+            Assert.IsType<InvalidBlockPreviousHashException>(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U) },
+                        fields =>
+                        {
+                            fields.PreviousHash = default(HashDigest<SHA256>);
+                            return fields;
+                        }
+                    ),
+                    FixtureEpoch + new TimeSpan(0, 1, 0)
+                )
+            );
+
+            // Block indices must be continous.
+            Assert.IsType<InvalidBlockIndexException>(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U) },
+                        fields =>
+                        {
+                            fields.Index = fields.Index == 0UL ? 0UL : 2UL;
+                            return fields;
+                        }
+                    ),
+                    FixtureEpoch + new TimeSpan(1, 1, 0)
+                )
+            );
+
+            // Block difficulties depend on interval between previous block
+            // and previous of previous block.  If an interval is shorter than
+            // BlockInterval (3 hours in this test case) it should be raised.
+            // Otherwise it should be dropped.  It should be always raised or
+            // dropped by only 1.
+            Assert.Null(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U), (3, 2U) }
+                    ),
+                    FixtureEpoch + new TimeSpan(3, 1, 0)
+                )
+            );
+            Assert.IsType<InvalidBlockDifficultyException>(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U), (3, 1U) }
+                    ),
+                    FixtureEpoch + new TimeSpan(3, 1, 0)
+                )
+            );
+            Assert.Null(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U), (5, 2U), (9, 1U) }
+                    ),
+                    FixtureEpoch + new TimeSpan(9, 1, 0)
+                )
+            );
+            Assert.Null(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U), (5, 2U), (9, 5U) }
+                    ),
+                    FixtureEpoch + new TimeSpan(9, 1, 0)
+                )
+            );
+
+            // A block's previous hash must refer to the hash of the block
+            // appeared right before.
+            Assert.IsType<InvalidBlockPreviousHashException>(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U), (5, 2U) },
+                        fields =>
+                        {
+                            if (fields.Index >= 2)
+                            {
+                                fields.PreviousHash =
+                                    default(HashDigest<SHA256>);
+                            }
+
+                            return fields;
+                        }
+                    ),
+                    FixtureEpoch + new TimeSpan(5, 1, 0)
+                )
+            );
+
+            // Block timestamp should not be overlapped.
+            Assert.IsType<InvalidBlockTimestampException>(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (2, 1U), (1, 2U) }
+                    ),
+                    FixtureEpoch + new TimeSpan(2, 1, 0)
+                )
+            );
+
+            // Returns null if blocks are valid.
+            Assert.Null(
+                policy.ValidateBlocks(
+                    MineBlocks(
+                        new[] { (0, 0U), (1, 1U), (3, 2U), (7, 3U), (9, 2U) }
+                    ),
+                    FixtureEpoch + new TimeSpan(9, 1, 0)
+                )
+            );
+        }
+
+        private IEnumerable<Block<BaseAction>> MineBlocks(
+            (int, uint)[] blockArgs,
+            Func<BlockFields, BlockFields> interprocess = null
+        )
+        {
+            _output.WriteLine($"MineBlocks({blockArgs.Length}):");
+            var miner = default(Address);
+            ulong i = 0;
+            HashDigest<SHA256>? previousHash = null;
+            foreach ((int timestampHour, uint d) in blockArgs)
+            {
+                uint difficulty = d;
+                var timestamp =
+                    FixtureEpoch + TimeSpan.FromHours(timestampHour);
+                if (interprocess != null)
+                {
+                    BlockFields fields = interprocess(
+                        new BlockFields
+                        {
+                            Index = i,
+                            Difficulty = difficulty,
+                            PreviousHash = previousHash,
+                            Timestamp = timestamp,
+                        }
+                    );
+                    i = fields.Index;
+                    difficulty = fields.Difficulty;
+                    previousHash = fields.PreviousHash;
+                    timestamp = fields.Timestamp;
+                }
+
+                Block<BaseAction> block = Block<BaseAction>.Mine(
+                    i,
+                    difficulty,
+                    miner,
+                    previousHash,
+                    timestamp,
+                    new Transaction<BaseAction>[0]
+                );
+                _output.WriteLine(
+                    $"#{i}: {block.Hash}, difficulty={block.Difficulty}, " +
+                    $"previousBlock={block.PreviousHash}, " +
+                    $"timestamp={block.Timestamp}"
+                );
+                yield return block;
+                previousHash = block.Hash;
+                i++;
+            }
+
+            _output.WriteLine(string.Empty);
+        }
+
+        private struct BlockFields
+        {
+            internal ulong Index;
+            internal uint Difficulty;
+            internal HashDigest<SHA256>? PreviousHash;
+            internal DateTime Timestamp;
+        }
+    }
+}

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Libplanet.Action;
+using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -24,7 +26,7 @@ namespace Libplanet.Tests.Net
         private readonly FileStoreFixture _fx2;
         private readonly FileStoreFixture _fx3;
 
-        private readonly List<Blockchain<BaseAction>> _blockchains;
+        private readonly List<BlockChain<BaseAction>> _blockchains;
         private readonly List<Swarm> _swarms;
 
         public SwarmTest(ITestOutputHelper output)
@@ -40,11 +42,11 @@ namespace Libplanet.Tests.Net
             _fx2 = new FileStoreFixture();
             _fx3 = new FileStoreFixture();
 
-            _blockchains = new List<Blockchain<BaseAction>>
+            _blockchains = new List<BlockChain<BaseAction>>
             {
-                new Blockchain<BaseAction>(_fx1.Store),
-                new Blockchain<BaseAction>(_fx2.Store),
-                new Blockchain<BaseAction>(_fx3.Store),
+                new BlockChain<BaseAction>(_fx1.Store),
+                new BlockChain<BaseAction>(_fx2.Store),
+                new BlockChain<BaseAction>(_fx3.Store),
             };
 
             _swarms = new List<Swarm>
@@ -75,7 +77,7 @@ namespace Libplanet.Tests.Net
         public async Task CanNotStartTwice()
         {
             Swarm swarm = _swarms[0];
-            Blockchain<BaseAction> chain = _blockchains[0];
+            BlockChain<BaseAction> chain = _blockchains[0];
 
             #pragma warning disable CS4014
             Task.Run(async () => { await swarm.StartAsync(chain); });
@@ -92,7 +94,7 @@ namespace Libplanet.Tests.Net
         public async Task CanStop()
         {
             Swarm swarm = _swarms[0];
-            Blockchain<BaseAction> chain = _blockchains[0];
+            BlockChain<BaseAction> chain = _blockchains[0];
 
             await swarm.StopAsync();
             Task task = Task.Run(async () =>
@@ -115,7 +117,7 @@ namespace Libplanet.Tests.Net
             Swarm b = _swarms[1];
             Swarm c = _swarms[2];
 
-            Blockchain<BaseAction> chain = _blockchains[0];
+            BlockChain<BaseAction> chain = _blockchains[0];
 
             DateTime lastDistA;
             Peer aAsPeer;
@@ -234,7 +236,7 @@ namespace Libplanet.Tests.Net
         public async Task CanBeCancelled()
         {
             Swarm swarm = _swarms[0];
-            Blockchain<BaseAction> chain = _blockchains[0];
+            BlockChain<BaseAction> chain = _blockchains[0];
             var cts = new CancellationTokenSource();
 
             Task task = Task.Run(
@@ -251,8 +253,8 @@ namespace Libplanet.Tests.Net
             Swarm swarmA = _swarms[0];
             Swarm swarmB = _swarms[1];
 
-            Blockchain<BaseAction> chainA = _blockchains[0];
-            Blockchain<BaseAction> chainB = _blockchains[1];
+            BlockChain<BaseAction> chainA = _blockchains[0];
+            BlockChain<BaseAction> chainB = _blockchains[1];
 
             Block<BaseAction> genesis = chainA.MineBlock(_fx1.Address1);
             chainB.Append(genesis); // chainA and chainB shares genesis block.
@@ -315,8 +317,8 @@ namespace Libplanet.Tests.Net
             Swarm swarmA = _swarms[0];
             Swarm swarmB = _swarms[1];
 
-            Blockchain<BaseAction> chainA = _blockchains[0];
-            Blockchain<BaseAction> chainB = _blockchains[1];
+            BlockChain<BaseAction> chainA = _blockchains[0];
+            BlockChain<BaseAction> chainB = _blockchains[1];
 
             Transaction<BaseAction> tx = Transaction<BaseAction>.Make(
                 new PrivateKey(),
@@ -362,9 +364,9 @@ namespace Libplanet.Tests.Net
             Swarm swarmB = _swarms[1];
             Swarm swarmC = _swarms[2];
 
-            Blockchain<BaseAction> chainA = _blockchains[0];
-            Blockchain<BaseAction> chainB = _blockchains[1];
-            Blockchain<BaseAction> chainC = _blockchains[2];
+            BlockChain<BaseAction> chainA = _blockchains[0];
+            BlockChain<BaseAction> chainB = _blockchains[1];
+            BlockChain<BaseAction> chainC = _blockchains[2];
 
             Transaction<BaseAction> tx = Transaction<BaseAction>.Make(
                 new PrivateKey(),
@@ -414,9 +416,9 @@ namespace Libplanet.Tests.Net
             Swarm swarmB = _swarms[1];
             Swarm swarmC = _swarms[2];
 
-            Blockchain<BaseAction> chainA = _blockchains[0];
-            Blockchain<BaseAction> chainB = _blockchains[1];
-            Blockchain<BaseAction> chainC = _blockchains[2];
+            BlockChain<BaseAction> chainA = _blockchains[0];
+            BlockChain<BaseAction> chainB = _blockchains[1];
+            BlockChain<BaseAction> chainC = _blockchains[2];
 
             // chainA, chainB and chainC shares genesis block.
             Block<BaseAction> genesis = chainA.MineBlock(_fx1.Address1);

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Action;
 using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
@@ -38,15 +39,16 @@ namespace Libplanet.Tests.Net
                 .CreateLogger()
                 .ForContext<SwarmTest>();
 
+            var policy = new BlockPolicy<BaseAction>();
             _fx1 = new FileStoreFixture();
             _fx2 = new FileStoreFixture();
             _fx3 = new FileStoreFixture();
 
             _blockchains = new List<BlockChain<BaseAction>>
             {
-                new BlockChain<BaseAction>(_fx1.Store),
-                new BlockChain<BaseAction>(_fx2.Store),
-                new BlockChain<BaseAction>(_fx3.Store),
+                new BlockChain<BaseAction>(policy, _fx1.Store),
+                new BlockChain<BaseAction>(policy, _fx2.Store),
+                new BlockChain<BaseAction>(policy, _fx3.Store),
             };
 
             _swarms = new List<Swarm>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -12,9 +12,9 @@ using Libplanet.Store;
 using Libplanet.Tx;
 
 [assembly: InternalsVisibleTo("Libplanet.Tests")]
-namespace Libplanet
+namespace Libplanet.Blockchain
 {
-    public class Blockchain<T> : IEnumerable<Block<T>>
+    public class BlockChain<T> : IEnumerable<Block<T>>
         where T : IAction
     {
         private static readonly TimeSpan BlockInterval = new TimeSpan(
@@ -23,7 +23,7 @@ namespace Libplanet
             seconds: 5
         );
 
-        public Blockchain(IStore store)
+        public BlockChain(IStore store)
         {
             Store = store;
             Blocks = new BlockSet<T>(store);
@@ -369,7 +369,7 @@ namespace Libplanet
                         .Where(states.ContainsKey)
                         .ToImmutableDictionary(a => a, a => states[a]));
                     var context = new ActionContext(
-                        from: tx.Sender,
+                        @from: tx.Sender,
                         to: tx.Recipient,
                         previousStates: prevState,
                         randomSeed: unchecked(txSeed++)

--- a/Libplanet/Blockchain/BlockLocator.cs
+++ b/Libplanet/Blockchain/BlockLocator.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 
-namespace Libplanet
+namespace Libplanet.Blockchain
 {
     internal class BlockLocator : IEnumerable<HashDigest<SHA256>>
     {

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -23,7 +23,7 @@ namespace Libplanet.Blockchain.Policies
         /// <param name="blockIntervalSeconds">Configures
         /// <see cref="BlockInterval"/> in seconds.  5 seconds by default.
         /// </param>
-        public BlockPolicy(uint blockIntervalSeconds = 5)
+        public BlockPolicy(int blockIntervalSeconds = 5)
             : this(
                 TimeSpan.FromSeconds(blockIntervalSeconds)
             )
@@ -38,6 +38,14 @@ namespace Libplanet.Blockchain.Policies
         /// </param>
         public BlockPolicy(TimeSpan blockInterval)
         {
+            if (blockInterval < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(blockInterval),
+                    "Interval between blocks cannot be negative."
+                );
+            }
+
             BlockInterval = blockInterval;
         }
 

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain.Policies
+{
+    public class BlockPolicy<T> : IBlockPolicy<T>
+        where T : IAction
+    {
+        public BlockPolicy(uint blockIntervalSeconds = 5)
+            : this(
+                TimeSpan.FromSeconds(blockIntervalSeconds)
+            )
+        {
+        }
+
+        public BlockPolicy(TimeSpan blockInterval)
+        {
+            BlockInterval = blockInterval;
+        }
+
+        public TimeSpan BlockInterval { get; }
+
+        public InvalidBlockException ValidateBlocks(
+            IEnumerable<Block<T>> blocks,
+            DateTime currentTime
+        )
+        {
+            HashDigest<SHA256>? prevHash = null;
+            DateTime? prevTimestamp = null;
+            IEnumerable<(ulong i, DifficultyExpectation)> indexedDifficulties =
+                ExpectDifficulties(blocks).Select(
+                    (exp, i) => { return ((ulong)i, exp); }
+                ).ToArray();
+
+            foreach (var (i, exp) in indexedDifficulties)
+            {
+                Trace.Assert(exp.Block != null);
+                Block<T> block = exp.Block;
+
+                if (i != block.Index)
+                {
+                    return new InvalidBlockIndexException(
+                        $"the expected block index is {i}, but its index is" +
+                        $" {block.Index}'"
+                    );
+                }
+
+                if (block.Difficulty < exp.Difficulty)
+                {
+                    return new InvalidBlockDifficultyException(
+                        $"the expected difficulty of the block #{i} " +
+                        $"is {exp.Difficulty}, but its difficulty is " +
+                        $"{block.Difficulty}'"
+                    );
+                }
+
+                if (block.PreviousHash != prevHash)
+                {
+                    if (prevHash == null)
+                    {
+                        return new InvalidBlockPreviousHashException(
+                            "the genesis block must have not previous block"
+                        );
+                    }
+
+                    return new InvalidBlockPreviousHashException(
+                        $"the block #{i} is not continuous from the " +
+                        $"block #{i - 1}; while previous block's hash is " +
+                        $"{prevHash}, the block #{i}'s pointer to " +
+                        "the previous hash refers to " +
+                        (block.PreviousHash?.ToString() ?? "nothing")
+                    );
+                }
+
+                if (block.Timestamp < prevTimestamp)
+                {
+                    return new InvalidBlockTimestampException(
+                        $"the block #{i}'s timestamp ({block.Timestamp}) is " +
+                        $"earlier than the block #{i - 1}'s ({prevTimestamp})"
+                    );
+                }
+
+                prevHash = block.Hash;
+                prevTimestamp = block.Timestamp;
+            }
+
+            return null;
+        }
+
+        public uint GetNextBlockDifficulty(IEnumerable<Block<T>> blocks)
+        {
+            return ExpectDifficulties(blocks, yieldNext: true)
+                .First(t => t.Block == null)
+                .Difficulty;
+        }
+
+        private IEnumerable<DifficultyExpectation> ExpectDifficulties(
+            IEnumerable<Block<T>> blocks, bool yieldNext = false)
+        {
+            DateTime? prevTimestamp = null;
+            DateTime? prevPrevTimestamp = null;
+
+            if (yieldNext)
+            {
+                blocks = blocks.Append(null);
+            }
+
+            bool genesis = true;
+            uint difficulty = 1;
+            prevTimestamp = blocks.FirstOrDefault()?.Timestamp;
+
+            foreach (Block<T> block in blocks)
+            {
+                if (genesis)
+                {
+                    // genesis block's difficulty is 0
+                    yield return new DifficultyExpectation
+                    {
+                        Difficulty = 0,
+                        Block = block,
+                    };
+                    genesis = false;
+                    continue;
+                }
+
+                bool needMore =
+                    prevPrevTimestamp != null &&
+                    (
+                        prevPrevTimestamp == null ||
+                        prevTimestamp - prevPrevTimestamp < BlockInterval
+                    );
+                difficulty = Math.Max(
+                    needMore ? difficulty + 1 : difficulty - 1,
+                    1
+                );
+                yield return new DifficultyExpectation
+                {
+                    Difficulty = difficulty,
+                    Block = block,
+                };
+
+                if (block != null)
+                {
+                    prevPrevTimestamp = prevTimestamp;
+                    prevTimestamp = block.Timestamp;
+                }
+            }
+        }
+
+        private struct DifficultyExpectation
+        {
+            internal Block<T> Block;
+
+            internal uint Difficulty;
+        }
+    }
+}

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -8,9 +8,21 @@ using Libplanet.Blocks;
 
 namespace Libplanet.Blockchain.Policies
 {
+    /// <summary>
+    /// A default implementation of <see cref="IBlockPolicy{T}"/> interface.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
     public class BlockPolicy<T> : IBlockPolicy<T>
         where T : IAction
     {
+        /// <summary>
+        /// Creates a <see cref="BlockPolicy{T}"/> with configuring
+        /// <see cref="BlockInterval"/> in seconds.
+        /// </summary>
+        /// <param name="blockIntervalSeconds">Configures
+        /// <see cref="BlockInterval"/> in seconds.  5 seconds by default.
+        /// </param>
         public BlockPolicy(uint blockIntervalSeconds = 5)
             : this(
                 TimeSpan.FromSeconds(blockIntervalSeconds)
@@ -18,13 +30,28 @@ namespace Libplanet.Blockchain.Policies
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="BlockPolicy{T}"/> with configuring
+        /// <see cref="BlockInterval"/>.
+        /// </summary>
+        /// <param name="blockInterval">Configures <see cref="BlockInterval"/>.
+        /// </param>
         public BlockPolicy(TimeSpan blockInterval)
         {
             BlockInterval = blockInterval;
         }
 
+        /// <summary>
+        /// An appropriate interval between consecutive <see cref="Block{T}"/>s.
+        /// It is usually from 20 to 30 seconds.
+        /// <para>If a previous interval took longer than this
+        /// <see cref="GetNextBlockDifficulty(IEnumerable{Block{T}})"/> method
+        /// raises the <see cref="Block{T}.Difficulty"/>.  If it took shorter
+        /// than this <see cref="Block{T}.Difficulty"/> is dropped.</para>
+        /// </summary>
         public TimeSpan BlockInterval { get; }
 
+        /// <inheritdoc />
         public InvalidBlockException ValidateBlocks(
             IEnumerable<Block<T>> blocks,
             DateTime currentTime
@@ -92,6 +119,7 @@ namespace Libplanet.Blockchain.Policies
             return null;
         }
 
+        /// <inheritdoc />
         public uint GetNextBlockDifficulty(IEnumerable<Block<T>> blocks)
         {
             return ExpectDifficulties(blocks, yieldNext: true)

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -5,14 +5,44 @@ using Libplanet.Blocks;
 
 namespace Libplanet.Blockchain.Policies
 {
+    /// <summary>
+    /// An interface to determine if consecutive <see cref="Block{T}"/>s are
+    /// valid, and to suggest how difficult a <see cref="Block{T}.Nonce"/>
+    /// for a <see cref="Block{T}"/> to be mined.
+    /// </summary>
+    /// <typeparam name="T">An <see cref="IAction"/> type.  It should match
+    /// to <see cref="Block{T}"/>'s type parameter.</typeparam>
     public interface IBlockPolicy<T>
         where T : IAction
     {
+        /// <summary>
+        /// Checks if <paramref name="blocks"/> are invalid, and if that
+        /// returns the reason.
+        /// <para>Note that it returns <c>null</c> when blocks are
+        /// <em>valid</em>.</para>
+        /// </summary>
+        /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to
+        /// validate.</param>
+        /// <param name="currentTime">The current time to be used to validate
+        /// of <see cref="Block{T}.Timestamp"/>s.
+        /// Usually <see cref="DateTime.UtcNow"/> is used.</param>
+        /// <returns>The reason why the given <paramref name="blocks"/> are
+        /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
+        /// <em>valid</em>.</returns>
         InvalidBlockException ValidateBlocks(
             IEnumerable<Block<T>> blocks,
             DateTime currentTime
         );
 
+        /// <summary>
+        /// Determines a right <see cref="Block{T}.Difficulty"/>
+        /// for a new <see cref="Block{T}"/> to be mined
+        /// right after the given <paramref name="blocks"/>.
+        /// </summary>
+        /// <param name="blocks">Consecutive <see cref="Block{T}"/>s to be
+        /// followed by a new <see cref="Block{T}"/> to be mined.</param>
+        /// <returns>A right <see cref="Block{T}.Difficulty"/>
+        /// for a new <see cref="Block{T}"/> to be mined.</returns>
         uint GetNextBlockDifficulty(IEnumerable<Block<T>> blocks);
     }
 }

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Blockchain.Policies
+{
+    public interface IBlockPolicy<T>
+        where T : IAction
+    {
+        InvalidBlockException ValidateBlocks(
+            IEnumerable<Block<T>> blocks,
+            DateTime currentTime
+        );
+
+        uint GetNextBlockDifficulty(IEnumerable<Block<T>> blocks);
+    }
+}

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -153,13 +153,14 @@ namespace Libplanet.Blocks
             Validate(DateTime.UtcNow);
         }
 
-        public void Validate(DateTime now)
+        public void Validate(DateTime currentTime)
         {
-            if (now + TimestampThreshold < Timestamp)
+            if (currentTime + TimestampThreshold < Timestamp)
             {
                 throw new InvalidBlockTimestampException(
                     $"The block #{Index}'s timestamp ({Timestamp}) is " +
-                    $"later than now ({now}, threshold: {TimestampThreshold})."
+                    $"later than now ({currentTime}, " +
+                    $"threshold: {TimestampThreshold})."
                 );
             }
 

--- a/Libplanet/Net/Messages/GetBlockHashes.cs
+++ b/Libplanet/Net/Messages/GetBlockHashes.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
+using Libplanet.Blockchain;
 using NetMQ;
 
 namespace Libplanet.Net.Messages


### PR DESCRIPTION
This patch abstracts out the standard between what kind of blocks are valid and what are invalid from blockchain objects.  It separates `IBlockPolicy<T>` (`where T : IAction`) and its default implementation `BlockPolicy<T>` from `BlockChain<T>` (renamed from `Blockchain<T>`).  Hard-coded interval between blocks (it was 5 seconds) now can be configured through `BlockPolicy<T>.BlockInterval`.  A new namespace `Libplanet.Blockchain` is also introduced.