### PR TITLE
API docs for Libplanet.Tx namespace and some adjustments

### DIFF
--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -629,6 +629,37 @@ namespace Libplanet.Tests.Tx
             tx.Validate();
         }
 
+        [Fact]
+        public void SignatureBufferIsIsolated()
+        {
+            Transaction<BaseAction> tx = _fx.Tx;
+            byte[] sig = tx.Signature;
+            for (int i = 0; i < sig.Length; i++)
+            {
+                sig[i] = 0;
+            }
+
+            Assert.NotEqual(new byte[sig.Length], tx.Signature);
+
+            var sig2 = new byte[tx.Signature.Length];
+            Array.Copy(tx.Signature, sig2, sig2.Length);
+            var tx2 = new Transaction<BaseAction>(
+                tx.Sender,
+                tx.PublicKey,
+                tx.Recipient,
+                tx.Timestamp,
+                tx.Actions,
+                sig2
+            );
+            for (int i = 0; i < sig2.Length; i++)
+            {
+                sig2[i] = 0;
+            }
+
+            Assert.NotEqual(new byte[sig.Length], tx2.Signature);
+            AssertBytesEqual(tx.Signature, tx2.Signature);
+        }
+
         [SuppressMessage(
             "Microsoft.StyleCop.CSharp.ReadabilityRules",
             "SA1118",

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -83,6 +83,16 @@ namespace Libplanet.Tests.Tx
                     timestamp
                 )
             );
+
+            // The actions parameter cannot be null.
+            Assert.Throws<ArgumentNullException>(() =>
+                Transaction<BaseAction>.Make(
+                    privateKey,
+                    recipient,
+                    null,
+                    timestamp
+                )
+            );
         }
 
         [Fact]
@@ -155,16 +165,52 @@ namespace Libplanet.Tests.Tx
                 0x3f,
             };
 
-            Assert.Throws<InvalidTxSignatureException>(() =>
-            {
+            // The publicKey parameter cannot be null.
+            Assert.Throws<ArgumentNullException>(() =>
+                new Transaction<BaseAction>(
+                    privateKey.PublicKey.ToAddress(),
+                    null,
+                    recipient,
+                    timestamp,
+                    new List<BaseAction>(),
+                    signature
+                )
+            );
+
+            // The actions parameter cannot be null.
+            Assert.Throws<ArgumentNullException>(() =>
+                new Transaction<BaseAction>(
+                    privateKey.PublicKey.ToAddress(),
+                    privateKey.PublicKey,
+                    recipient,
+                    timestamp,
+                    null,
+                    signature
+                )
+            );
+
+            // The signature parameter cannot be null.
+            Assert.Throws<ArgumentNullException>(() =>
                 new Transaction<BaseAction>(
                     privateKey.PublicKey.ToAddress(),
                     privateKey.PublicKey,
                     recipient,
                     timestamp,
                     new List<BaseAction>(),
-                    invalidSignature);
-            });
+                    null
+                )
+            );
+
+            Assert.Throws<InvalidTxSignatureException>(() =>
+                new Transaction<BaseAction>(
+                    privateKey.PublicKey.ToAddress(),
+                    privateKey.PublicKey,
+                    recipient,
+                    timestamp,
+                    new List<BaseAction>(),
+                    invalidSignature
+                )
+            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -73,6 +73,16 @@ namespace Libplanet.Tests.Tx
                 ),
                 tx.Id
             );
+
+            // The privateKey parameter cannot be null.
+            Assert.Throws<ArgumentNullException>(() =>
+                Transaction<BaseAction>.Make(
+                    null,
+                    recipient,
+                    new List<BaseAction>(),
+                    timestamp
+                )
+            );
         }
 
         [Fact]

--- a/Libplanet.Tests/Tx/TxIdTest.cs
+++ b/Libplanet.Tests/Tx/TxIdTest.cs
@@ -23,7 +23,9 @@ namespace Libplanet.Tests.Tx
                 }
 
                 byte[] bytes = TestUtils.GetRandomBytes(size);
-                Assert.Throws<ArgumentException>(() => new TxId(bytes));
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => new TxId(bytes)
+                );
             }
         }
 

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -112,8 +112,8 @@ namespace Libplanet.Store
                 FileMode.Append, FileAccess.Write))
             {
                 var offset = stream.Position;
-                stream.Write(txId.ToByteArray(), 0, TxId.RequiredLength);
-                return Convert.ToInt64(offset / (float)TxId.RequiredLength);
+                stream.Write(txId.ToByteArray(), 0, TxId.Size);
+                return Convert.ToInt64(offset / (float)TxId.Size);
             }
         }
 
@@ -214,8 +214,8 @@ namespace Libplanet.Store
                 {
                     while (true)
                     {
-                        var txIdBytes = new byte[TxId.RequiredLength];
-                        var length = f.Read(txIdBytes, 0, TxId.RequiredLength);
+                        var txIdBytes = new byte[TxId.Size];
+                        var length = f.Read(txIdBytes, 0, TxId.Size);
                         if (length == 0)
                         {
                             break;

--- a/Libplanet/Tx/InvalidTxException.cs
+++ b/Libplanet/Tx/InvalidTxException.cs
@@ -2,9 +2,14 @@ using System;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// Serves as the base class for exceptions relevent to
+    /// <see cref="Transaction{T}"/>.
+    /// </summary>
     public abstract class InvalidTxException : Exception
     {
         protected InvalidTxException(string message)
+            : base(message)
         {
         }
     }

--- a/Libplanet/Tx/InvalidTxIdException.cs
+++ b/Libplanet/Tx/InvalidTxIdException.cs
@@ -2,9 +2,21 @@ using System;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// The exception that is thrown when a given <see cref="TxId"/> cannot be
+    /// found.
+    /// </summary>
+    /// <remarks>This does <em>not</em> mean a given value is an invalid
+    /// encoding of <see cref="TxId"/>, but there is no corresponding entry to
+    /// a given <see cref="TxId"/>, which is <em>valid</em>.</remarks>
     [Serializable]
     public class InvalidTxIdException : InvalidTxException
     {
+        /// <summary>
+        /// Creates a new <see cref="InvalidTxIdException"/> object.
+        /// </summary>
+        /// <param name="message">Specifies an <see cref="Exception.Message"/>.
+        /// </param>
         public InvalidTxIdException(string message)
             : base(message)
         {

--- a/Libplanet/Tx/InvalidTxPublicKeyException.cs
+++ b/Libplanet/Tx/InvalidTxPublicKeyException.cs
@@ -2,9 +2,19 @@ using System;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// The exception that is thrown when a <see cref="Transaction{T}"/>'s
+    /// <see cref="Transaction{T}.Sender"/> is not derived from its
+    /// <see cref="Transaction{T}.PublicKey"/>.
+    /// </summary>
     [Serializable]
     public class InvalidTxPublicKeyException : InvalidTxException
     {
+        /// <summary>
+        /// Creates a new <see cref="InvalidTxPublicKeyException"/> object.
+        /// </summary>
+        /// <param name="message">Specifies an <see cref="Exception.Message"/>.
+        /// </param>
         public InvalidTxPublicKeyException(string message)
             : base(message)
         {

--- a/Libplanet/Tx/InvalidTxSignatureException.cs
+++ b/Libplanet/Tx/InvalidTxSignatureException.cs
@@ -2,9 +2,18 @@ using System;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// The exception that is thrown when a <see cref="Transaction{T}"/>'s
+    /// <see cref="Transaction{T}.Signature"/> is invalid.
+    /// </summary>
     [Serializable]
     public class InvalidTxSignatureException : InvalidTxException
     {
+        /// <summary>
+        /// Creates a new <see cref="InvalidTxSignatureException"/> object.
+        /// </summary>
+        /// <param name="message">Specifies an <see cref="Exception.Message"/>.
+        /// </param>
         public InvalidTxSignatureException(string message)
             : base(message)
         {

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -14,6 +14,17 @@ using Libplanet.Serialization;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// Consists of <see cref="IAction"/> and is signed to be included in
+    /// a <see cref="Blocks.Block{T}"/> and transmitted over the network.
+    /// </summary>
+    /// <typeparam name="T">A subtype of <see cref="IAction"/> to include.
+    /// Each game usually defines its own abstact base class which implements
+    /// <see cref="IAction"/>, and uses it for this type parameter.
+    /// This type parameter is aligned with <see cref="Blocks.Block{T}"/>'s
+    /// and <see cref="Blockchain.BlockChain{T}"/>'s type parameters.
+    /// </typeparam>
+    /// <seealso cref="IAction"/>
     public class Transaction<T> : ISerializable, IEquatable<Transaction<T>>
         where T : IAction
     {
@@ -25,6 +36,43 @@ namespace Libplanet.Tx
             .Where(t => t.IsDefined(typeof(ActionTypeAttribute)))
             .ToDictionary(ActionTypeAttribute.ValueOf, t => t);
 
+        /// <summary>
+        /// Creates a new <see cref="Transaction{T}"/>.
+        /// </summary>
+        /// <param name="sender">An <see cref="Address"/> of the account
+        /// who signs this transaction.  If this is not derived from <paramref
+        /// name="publicKey"/> <see cref="InvalidTxPublicKeyException"/> is
+        /// thrown.  This goes to the <see cref="Sender"/> property.</param>
+        /// <param name="publicKey">A <see cref="PublicKey"/> of the account
+        /// who signs this transaction.  If this does not match to <paramref
+        /// name="sender"/> address <see cref="InvalidTxPublicKeyException"/>
+        /// is thrown.  This cannot be <c>null</c>.  This goes to
+        /// the <see cref="PublicKey"/> property.</param>
+        /// <param name="recipient">An <see cref="Address"/> of the account
+        /// who receives this transaction.  This goes to
+        /// the <see cref="Recipient"/> property.</param>
+        /// <param name="timestamp">The time this <see cref="Transaction{T}"/>
+        /// is created and signed.  This goes to the <see cref="Timestamp"/>
+        /// property.</param>
+        /// <param name="actions">A list of <see cref="IAction"/>s.  This
+        /// can be empty, but cannot be <c>null</c>.  This goes to
+        /// the <see cref="Actions"/> property.</param>
+        /// <param name="signature">A digital signature of the content of
+        /// this <see cref="Transaction{T}"/>.  This has to be signed by
+        /// the account who corresponds to <paramref name="publicKey"/>,
+        /// or it will throw <see cref="InvalidTxSignatureException"/>.
+        /// This goes to the <see cref="Signature"/> property.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>null</c>
+        /// is passed to <paramref name="signature"/>,
+        /// <paramref name="actions"/>, or <paramref name="publicKey"/>.
+        /// </exception>
+        /// <exception cref="InvalidTxSignatureException">Thrown when its
+        /// <paramref name="signature"/> is invalid or not signed by
+        /// the account who corresponds to <paramref name="publicKey"/>.
+        /// </exception>
+        /// <exception cref="InvalidTxPublicKeyException">Thrown when its
+        /// <paramref name="sender"/> is not derived from its
+        /// <paramref name="publicKey"/>.</exception>
         public Transaction(
             Address sender,
             PublicKey publicKey,
@@ -80,6 +128,12 @@ namespace Libplanet.Tx
             Signature = new byte[0];
         }
 
+        /// <summary>
+        /// A unique identifier derived from this <see cref="Transaction{T}"/>'s
+        /// content.
+        /// <para>For more characteristics, see <see cref="TxId"/> type.</para>
+        /// </summary>
+        /// <seealso cref="TxId"/>
         public TxId Id
         {
             get
@@ -92,27 +146,97 @@ namespace Libplanet.Tx
             }
         }
 
+        /// <summary>
+        /// A <see cref="PublicKey"/> of the account who signs this transaction.
+        /// This is derived from the <see cref="PublicKey"/>.
+        /// </summary>
         public Address Sender { get; }
 
+        /// <summary>
+        /// An <see cref="Address"/> of the account who
+        /// receives this transaction.
+        /// </summary>
         public Address Recipient { get; }
 
+        /// <summary>
+        /// A digital signature of the content of this
+        /// <see cref="Transaction{T}"/>.  This is signed by the account
+        /// who corresponds to <see cref="PublicKey"/>.
+        /// This cannot be <c>null</c>.
+        /// </summary>
         public byte[] Signature { get; }
+        /*
+        FIXME: This should be an ImmutableArray<byte>.
+        Currently as this is mutable the whole transaction is also mutable.
+        */
 
+        /// <summary>
+        /// A list of <see cref="IAction"/>s.  These are executed in the order.
+        /// This can be empty, but cannot be <c>null</c>.
+        /// </summary>
         public IList<T> Actions { get; }
 
+        /// <summary>
+        /// The time this <see cref="Transaction{T}"/> is created and signed.
+        /// </summary>
         public DateTime Timestamp { get; }
 
+        /// <summary>
+        /// A <see cref="PublicKey"/> of the account who signs this
+        /// <see cref="Transaction{T}"/>.
+        /// The <see cref="Sender"/> address is always corresponding to this
+        /// for each transaction.  This cannot be <c>null</c>.
+        /// </summary>
         public PublicKey PublicKey { get; }
 
+        /// <summary>
+        /// Decodes a transaction's
+        /// <a href="https://bencodex.org/">Bencodex</a> representation.
+        /// </summary>
+        /// <param name="bytes">A <a href="https://bencodex.org/">Bencodex</a>
+        /// representation of a transaction.</param>
+        /// <returns>A decoded <see cref="Transaction{T}"/> object.</returns>
+        /// <seealso cref="ToBencodex(bool)"/>
         public static Transaction<T> FromBencodex(byte[] bytes)
         {
             var serializer = new BencodexFormatter<Transaction<T>>();
             using (var stream = new MemoryStream(bytes))
             {
+                // FIXME: Shouldn't it call Validate() here?
                 return (Transaction<T>)serializer.Deserialize(stream);
             }
         }
 
+        /// <summary>
+        /// A fa&#xe7;ade factory to create a new <see cref="Transaction{T}"/>.
+        /// Unlike the <see cref="Transaction(Address, PublicKey, Address,
+        /// DateTime, IList{T}, byte[])"/> constructor, it automatically signs,
+        /// and fills the appropriate <see cref="Sender"/> and
+        /// <see cref="PublicKey"/> properties using the given
+        /// <paramref name="privateKey"/>.  However, the <paramref
+        /// name="privateKey"/> in itself is not included in the created
+        /// <see cref="Transaction{T}"/>.
+        /// </summary>
+        /// <param name="privateKey">A <see cref="PrivateKey"/> of the account
+        /// who creates and signs a new transaction.  This key is used to fill
+        /// the <see cref="Sender"/>, <see cref="PublicKey"/>, and
+        /// <see cref="Signature"/> properties, but this in itself is not
+        /// included in the transaction.</param>
+        /// <param name="recipient">An <see cref="Address"/> of the account
+        /// who receives this transaction.  This goes to
+        /// the <see cref="Recipient"/> property.</param>
+        /// <param name="actions">A list of <see cref="IAction"/>s.  This
+        /// can be empty, but cannot be <c>null</c>.  This goes to
+        /// the <see cref="Actions"/> property.</param>
+        /// <param name="timestamp">The time this <see cref="Transaction{T}"/>
+        /// is created and signed.  This goes to the <see cref="Timestamp"/>
+        /// property.</param>
+        /// <returns>A created new <see cref="Transaction{T}"/> signed by
+        /// the given <paramref name="privateKey"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <c>null</c>
+        /// is passed to <paramref name="privateKey"/> or
+        /// or <paramref name="actions"/>.
+        /// </exception>
         public static Transaction<T> Make(
             PrivateKey privateKey,
             Address recipient,
@@ -144,6 +268,20 @@ namespace Libplanet.Tx
             );
         }
 
+        /// <summary>
+        /// Encodes this <see cref="Transaction{T}"/> into a <see cref="byte"/>
+        /// array.
+        /// <para>This is an inverse function of
+        /// <see cref="FromBencodex(byte[])"/> method
+        /// where <paramref name="sign"/> is <c>true</c>.</para>
+        /// </summary>
+        /// <param name="sign">Whether to include its <see cref="Signature"/>.
+        /// Note that an encoding without signature cannot be decoded using
+        /// <see cref="FromBencodex(byte[])"/> method.
+        /// </param>
+        /// <returns>A <a href="https://bencodex.org/">Bencodex</a>
+        /// representation of this <see cref="Transaction{T}"/>.</returns>
+        /// <seealso cref="FromBencodex(byte[])"/>
         public byte[] ToBencodex(bool sign)
         {
             var serializer = new BencodexFormatter<Transaction<T>>
@@ -163,6 +301,17 @@ namespace Libplanet.Tx
             }
         }
 
+        /// <summary>
+        /// Validates this <see cref="Transaction{T}"/>.  If there is something
+        /// invalid it throws an exception.  If valid it does nothing.
+        /// </summary>
+        /// <exception cref="InvalidTxSignatureException">Thrown when its
+        /// <see cref="Transaction{T}.Signature"/> is invalid or not signed by
+        /// the account who corresponds to its <see cref="PublicKey"/>.
+        /// </exception>
+        /// <exception cref="InvalidTxPublicKeyException">Thrown when its
+        /// <see cref="Transaction{T}.Sender"/> is not derived from its
+        /// <see cref="Transaction{T}.PublicKey"/>.</exception>
         public void Validate()
         {
             if (!PublicKey.Verify(ToBencodex(false), Signature))
@@ -182,6 +331,7 @@ namespace Libplanet.Tx
             }
         }
 
+        /// <inheritdoc />
         public void GetObjectData(
             SerializationInfo info,
             StreamingContext context)
@@ -193,11 +343,13 @@ namespace Libplanet.Tx
             rawTx.GetObjectData(info, context);
         }
 
+        /// <inheritdoc />
         public bool Equals(Transaction<T> other)
         {
             return Id.Equals(other.Id);
         }
 
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj))
@@ -208,6 +360,7 @@ namespace Libplanet.Tx
             return obj is Transaction<T> other && Equals(other);
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Id.GetHashCode();

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -119,6 +119,11 @@ namespace Libplanet.Tx
             IList<T> actions,
             DateTime timestamp)
         {
+            if (privateKey == null)
+            {
+                throw new ArgumentNullException(nameof(privateKey));
+            }
+
             PublicKey publicKey = privateKey.PublicKey;
             var sender = new Address(publicKey);
 

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -36,6 +36,8 @@ namespace Libplanet.Tx
             .Where(t => t.IsDefined(typeof(ActionTypeAttribute)))
             .ToDictionary(ActionTypeAttribute.ValueOf, t => t);
 
+        private byte[] _signature;
+
         /// <summary>
         /// Creates a new <see cref="Transaction{T}"/>.
         /// </summary>
@@ -61,7 +63,8 @@ namespace Libplanet.Tx
         /// this <see cref="Transaction{T}"/>.  This has to be signed by
         /// the account who corresponds to <paramref name="publicKey"/>,
         /// or it will throw <see cref="InvalidTxSignatureException"/>.
-        /// This goes to the <see cref="Signature"/> property.</param>
+        /// This is copied and then assigned to the <see cref="Signature"/>
+        /// property.</param>
         /// <exception cref="ArgumentNullException">Thrown when <c>null</c>
         /// is passed to <paramref name="signature"/>,
         /// <paramref name="actions"/>, or <paramref name="publicKey"/>.
@@ -164,11 +167,24 @@ namespace Libplanet.Tx
         /// who corresponds to <see cref="PublicKey"/>.
         /// This cannot be <c>null</c>.
         /// </summary>
-        public byte[] Signature { get; }
-        /*
-        FIXME: This should be an ImmutableArray<byte>.
-        Currently as this is mutable the whole transaction is also mutable.
-        */
+        /// <returns>A new <see cref="byte"/> array of this transaction's
+        /// signature.  Changing a returned array does not affect the internal
+        /// state of this <see cref="Transaction{T}"/> object.</returns>
+        public byte[] Signature
+        {
+            get
+            {
+                var sig = new byte[_signature.Length];
+                Array.Copy(_signature, sig, _signature.Length);
+                return sig;
+            }
+
+            private set
+            {
+                _signature = new byte[value.Length];
+                Array.Copy(value, _signature, value.Length);
+            }
+        }
 
         /// <summary>
         /// A list of <see cref="IAction"/>s.  These are executed in the order.

--- a/Libplanet/Tx/TxId.cs
+++ b/Libplanet/Tx/TxId.cs
@@ -5,28 +5,52 @@ using System.Linq;
 
 namespace Libplanet.Tx
 {
+    /// <summary>
+    /// <see cref="TxId"/>, abbreviation of transaction identifier,
+    /// is a SHA-256 digest derived from a <see cref="Transaction{T}"/>'s
+    /// content.
+    /// <para>As it is a SHA-256 digest, it consists of 32 <see cref="byte"/>s,
+    /// and 64 characters in hexadecimal.
+    /// (See also <see cref="Size"/> constant.)</para>
+    /// </summary>
+    /// <seealso cref="Transaction{T}.Id"/>
     #pragma warning disable CS0282
     [Uno.GeneratedEquality]
     public partial struct TxId
     #pragma warning restore CS0282
     {
-        public const int RequiredLength = 32;
+        /// <summary>
+        /// The <see cref="byte"/> size that each <see cref="TxId"/> takes.
+        /// <para>As a txid is a SHA-256 digest, it is 32 <see cref="byte"/>s.
+        /// </para>
+        /// </summary>
+        public const int Size = 32;
+
         private ImmutableArray<byte> _byteArray;
 
+        /// <summary>
+        /// Converts a <see cref="byte"/> array into a <see cref="TxId"/>.
+        /// </summary>
+        /// <param name="txid">A <see cref="byte"/> array that encodes
+        /// a <see cref="TxId"/>.  It must not be <c>null</c>,
+        /// and its <see cref="Array.Length"/> must be the same to
+        /// <see cref="Size"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the given
+        /// <paramref name="txid"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the given
+        /// <paramref name="txid"/>'s <see cref="Array.Length"/> is not
+        /// the same to the required <see cref="Size"/>.</exception>
         public TxId(byte[] txid)
         {
             if (txid == null)
             {
-                throw new ArgumentNullException(
-                    $"It must not be null.",
-                    nameof(txid)
-                );
+                throw new ArgumentNullException(nameof(txid));
             }
 
-            if (txid.Length != RequiredLength)
+            if (txid.Length != Size)
             {
-                throw new ArgumentException(
-                    $"It must be {RequiredLength} bytes.",
+                throw new ArgumentOutOfRangeException(
+                    $"TxId must be {Size} bytes.",
                     nameof(txid)
                 );
             }
@@ -42,6 +66,13 @@ namespace Libplanet.Tx
             #pragma warning restore CS0103
         }
 
+        /// <summary>
+        /// A bare immutable <see cref="byte"/> array of
+        /// this <see cref="TxId"/>.
+        /// </summary>
+        /// <remarks>It is immutable.  For a mutable array, use
+        /// <see cref="ToByteArray()"/> method instead.</remarks>
+        /// <seealso cref="ToByteArray()"/>
         [Uno.EqualityKey]
         public ImmutableArray<byte> ByteArray
         {
@@ -49,23 +80,40 @@ namespace Libplanet.Tx
             {
                 if (_byteArray.IsDefault)
                 {
-                    _byteArray = new byte[RequiredLength].ToImmutableArray();
+                    _byteArray = new byte[Size].ToImmutableArray();
                 }
 
                 return _byteArray;
             }
         }
 
+        /// <summary>
+        /// Gets a bare mutable <see cref="byte"/> array of
+        /// this <see cref="TxId"/>.
+        /// </summary>
+        /// <returns>A new mutable <see cref="byte"/> array of
+        /// this <see cref="TxId"/>.
+        /// Since a returned array is created every time the method is called,
+        /// any mutations on that array does not affect to
+        /// the <see cref="TxId"/> object.
+        /// </returns>
+        /// <seealso cref="ByteArray"/>
         [Pure]
         public byte[] ToByteArray() => ByteArray.ToArray();
 
+        /// <summary>
+        /// Gets a hexadecimal form of a <see cref="TxId"/>.
+        /// </summary>
+        /// <returns>64 hexadecimal characters.</returns>
         [Pure]
         public string ToHex() => ByteUtil.Hex(ToByteArray());
 
+        /// <summary>
+        /// Gets a <see cref="TxId"/>'s representative string.
+        /// </summary>
+        /// <returns>A string which represents this <see cref="TxId"/>.
+        /// </returns>
         [Pure]
-        public override string ToString()
-        {
-            return ToHex();
-        }
+        public override string ToString() => ToHex();
     }
 }


### PR DESCRIPTION
Wrote API docs for `Libplanet.Tx` namespace, and fixed some error-prone behaviors:

- The public constructor of `Transaction` had thrown `NullReferenceException` when some parameters of reference types.  It's changed to throw `ArgumentNullException` instead.  See also added tests.

- `Transaction.Signature` property had shared its internal state with others.  That means, if a `byte` array returned by the property or will be passed to the constructor mutates it affects the `Transaction` object too.  It's now changed to be copied when it is taken through the public constructor or returned through the property.  See also added tests.

    It maybe better to be `ImmutableArray<byte>` or to have its own type named `Signature`.