### PR TITLE
Replace DateTime with DateTimeOffset

### DIFF
--- a/Libplanet.Explorer/ViewModels/TransactionViewModel.cs
+++ b/Libplanet.Explorer/ViewModels/TransactionViewModel.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Explorer.ViewModels
     {
         public string Id { get; set; }
         public byte[] Signature { get; set; }
-        public DateTime Timestamp { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
         public string Sender { get; set; }
         public string Recipient { get; set; }
         public IEnumerable<Dictionary<string, object>> Actions { get; set; }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -106,7 +106,7 @@ namespace Libplanet.Tests.Blockchain
                 new PrivateKey(),
                 _fx.Address1,
                 actions1,
-                DateTime.UtcNow
+                DateTimeOffset.UtcNow
             );
 
             _blockChain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx1 });
@@ -133,7 +133,7 @@ namespace Libplanet.Tests.Blockchain
                 new PrivateKey(),
                 _fx.Address1,
                 actions2,
-                DateTime.UtcNow
+                DateTimeOffset.UtcNow
             );
 
             _blockChain.StageTransactions(new HashSet<Transaction<BaseAction>> { tx2 });

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -15,8 +15,8 @@ namespace Libplanet.Tests.Blockchain.Policies
 {
     public class BlockPolicyTest : IClassFixture<FileStoreFixture>
     {
-        private static readonly DateTime FixtureEpoch =
-            new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTimeOffset FixtureEpoch =
+            new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         private readonly ITestOutputHelper _output;
 
@@ -277,7 +277,7 @@ namespace Libplanet.Tests.Blockchain.Policies
             internal long Index;
             internal int Difficulty;
             internal HashDigest<SHA256>? PreviousHash;
-            internal DateTime Timestamp;
+            internal DateTimeOffset Timestamp;
         }
     }
 }

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(0, _fx.Genesis.Index);
             Assert.Equal(0, _fx.Genesis.Difficulty);
             Assert.Null(_fx.Genesis.PreviousHash);
-            Assert.Equal(new DateTime(2018, 11, 29), _fx.Genesis.Timestamp);
+            Assert.Equal(new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero), _fx.Genesis.Timestamp);
             Assert.Equal(
                 new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
                 _fx.Genesis.RewardBeneficiary);
@@ -43,7 +43,7 @@ namespace Libplanet.Tests.Blocks
             Assert.Equal(1, _fx.Next.Index);
             Assert.Equal(1, _fx.Next.Difficulty);
             Assert.Equal(_fx.Genesis.Hash, _fx.Next.PreviousHash);
-            Assert.Equal(new DateTime(2018, 11, 30), _fx.Next.Timestamp);
+            Assert.Equal(new DateTimeOffset(2018, 11, 30, 0, 0, 0, TimeSpan.Zero), _fx.Next.Timestamp);
             Assert.Equal(
                 new Address("21744f4f08db23e044178dafb8273aeb5ebe6644"),
                 _fx.Next.RewardBeneficiary);
@@ -164,7 +164,7 @@ namespace Libplanet.Tests.Blocks
         [Fact]
         public void CanDetectInvalidTimestamp()
         {
-            DateTime now = DateTime.UtcNow;
+            DateTimeOffset now = DateTimeOffset.UtcNow;
             var block = Block<BaseAction>.Mine(
                 _fx.Next.Index,
                 _fx.Next.Difficulty,

--- a/Libplanet.Tests/Net/PeerSetDeltaTest.cs
+++ b/Libplanet.Tests/Net/PeerSetDeltaTest.cs
@@ -18,7 +18,7 @@ namespace Libplanet.Tests.Net
                     new PrivateKey().PublicKey,
                     new[] { new Uri("inproc://a") }
                 ),
-                DateTime.UtcNow,
+                DateTimeOffset.UtcNow,
                 new[]
                 {
                     new Peer(

--- a/Libplanet.Tests/Net/SwarmTest.cs
+++ b/Libplanet.Tests/Net/SwarmTest.cs
@@ -121,7 +121,7 @@ namespace Libplanet.Tests.Net
 
             BlockChain<BaseAction> chain = _blockchains[0];
 
-            DateTime lastDistA;
+            DateTimeOffset lastDistA;
             Peer aAsPeer;
 
             try
@@ -326,7 +326,7 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 new PrivateKey().PublicKey.ToAddress(),
                 new BaseAction[] { },
-                DateTime.UtcNow
+                DateTimeOffset.UtcNow
             );
             chainB.StageTransactions(new[] { tx }.ToHashSet());
             chainB.MineBlock(_fx1.Address1);
@@ -374,7 +374,7 @@ namespace Libplanet.Tests.Net
                 new PrivateKey(),
                 new PrivateKey().PublicKey.ToAddress(),
                 new BaseAction[] { },
-                DateTime.UtcNow
+                DateTimeOffset.UtcNow
             );
 
             chainA.StageTransactions(new[] { tx }.ToHashSet());
@@ -479,7 +479,7 @@ namespace Libplanet.Tests.Net
             }
         }
 
-        private async Task EnsureRecvAsync(Swarm swarm, Peer peer = null, DateTime? lastReceived = null)
+        private async Task EnsureRecvAsync(Swarm swarm, Peer peer = null, DateTimeOffset? lastReceived = null)
         {
             while (true)
             {
@@ -492,7 +492,7 @@ namespace Libplanet.Tests.Net
                     break;
                 }
 
-                DateTime? lastSeen = null;
+                DateTimeOffset? lastSeen = null;
                 if (peer == null)
                 {
                     lastSeen = swarm.LastReceived;
@@ -505,7 +505,7 @@ namespace Libplanet.Tests.Net
                     }
                     else
                     {
-                        foreach (KeyValuePair<Peer, DateTime> kv in swarm.LastSeenTimestamps)
+                        foreach (KeyValuePair<Peer, DateTimeOffset> kv in swarm.LastSeenTimestamps)
                         {
                             if (peer.PublicKey == kv.Key.PublicKey)
                             {

--- a/Libplanet.Tests/Store/FileStoreFixture.cs
+++ b/Libplanet.Tests/Store/FileStoreFixture.cs
@@ -121,7 +121,7 @@ namespace Libplanet.Tests.Store
         {
             var privateKey = new PrivateKey();
             Address recipient = privateKey.PublicKey.ToAddress();
-            var timestamp = new DateTime(2018, 11, 21);
+            var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
             return Transaction<BaseAction>.Make(
                 privateKey,
                 recipient,

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -81,7 +81,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             var rewardBenificiary = new Address(
                 "21744f4f08db23e044178dafb8273aeb5ebe6644"
             );
-            var timestamp = new DateTime(2018, 11, 29);
+            var timestamp = new DateTimeOffset(2018, 11, 29, 0, 0, 0, TimeSpan.Zero);
             return new Block<T>(
                 index: 0,
                 difficulty: 0,
@@ -108,7 +108,7 @@ Actual:   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             const long index = 1;
             const int difficulty = 1;
             HashDigest<SHA256> previousHash = previousBlock.Hash;
-            DateTime timestamp = previousBlock.Timestamp.AddDays(1);
+            DateTimeOffset timestamp = previousBlock.Timestamp.AddDays(1);
             Address rewardBeneficiary = previousBlock.RewardBeneficiary.Value;
 
             if (nonce == null)

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -32,7 +32,7 @@ namespace Libplanet.Tests.Tx
                 }
             );
             var recipient = new Address(privateKey.PublicKey);
-            var timestamp = new DateTime(2018, 11, 21);
+            var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
             Transaction<BaseAction> tx = Transaction<BaseAction>.Make(
                 privateKey,
                 recipient,
@@ -108,7 +108,7 @@ namespace Libplanet.Tests.Tx
                 }
             );
             var recipient = new Address(privateKey.PublicKey);
-            var timestamp = new DateTime(2018, 11, 21);
+            var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
             var signature = new byte[]
             {
                 0x30, 0x45, 0x02, 0x21, 0x00, 0x9b, 0x8e, 0xb8, 0xb8, 0x6b,
@@ -351,7 +351,7 @@ namespace Libplanet.Tests.Tx
             Assert.Equal(publicKey, tx.PublicKey);
             Assert.Equal(new Address(publicKey), tx.Recipient);
             Assert.Equal(new Address(publicKey), tx.Sender);
-            Assert.Equal(new DateTime(2018, 11, 21), tx.Timestamp);
+            Assert.Equal(new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero), tx.Timestamp);
             Assert.Equal(
                 new byte[]
                 {
@@ -441,7 +441,7 @@ namespace Libplanet.Tests.Tx
             Assert.Equal(publicKey, tx.PublicKey);
             Assert.Equal(new Address(publicKey), tx.Recipient);
             Assert.Equal(new Address(publicKey), tx.Sender);
-            Assert.Equal(new DateTime(2018, 11, 21), tx.Timestamp);
+            Assert.Equal(new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero), tx.Timestamp);
             Assert.Equal(
                 new byte[]
                 {
@@ -501,7 +501,7 @@ namespace Libplanet.Tests.Tx
                 }
             );
             var recipient = new Address(privateKey.PublicKey);
-            var timestamp = new DateTime(2018, 11, 21);
+            var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
             Transaction<BaseAction> tx = Transaction<BaseAction>.Make(
                 privateKey,
                 recipient,
@@ -603,7 +603,7 @@ namespace Libplanet.Tests.Tx
                 }
             );
             var recipient = new Address(privateKey.PublicKey);
-            var timestamp = new DateTime(2018, 11, 21);
+            var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
             Transaction<BaseAction> tx = Transaction<BaseAction>.Make(
                 privateKey,
                 recipient,

--- a/Libplanet.Tests/Tx/TxFixture.cs
+++ b/Libplanet.Tests/Tx/TxFixture.cs
@@ -14,7 +14,7 @@ namespace Libplanet.Tests.Tx
                 ByteUtil.ParseHex(
                     "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76"));
             var recipient = new Address(privateKey.PublicKey);
-            var timestamp = new DateTime(2018, 11, 21);
+            var timestamp = new DateTimeOffset(2018, 11, 21, 0, 0, 0, TimeSpan.Zero);
 
             Tx = Transaction<BaseAction>.Make(
                 privateKey,

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -55,7 +55,8 @@ namespace Libplanet.Blockchain
             }
         }
 
-        public void Validate(IEnumerable<Block<T>> blocks, DateTime currentTime)
+        public void Validate(
+            IEnumerable<Block<T>> blocks, DateTimeOffset currentTime)
         {
             foreach (Block<T> block in blocks)
             {
@@ -112,7 +113,7 @@ namespace Libplanet.Blockchain
             return states;
         }
 
-        public void Append(Block<T> block, DateTime currentTime)
+        public void Append(Block<T> block, DateTimeOffset currentTime)
         {
             Validate(Enumerable.Append(this, block), currentTime);
             Blocks[block.Hash] = block;
@@ -130,7 +131,8 @@ namespace Libplanet.Blockchain
             }
         }
 
-        public void Append(Block<T> block) => Append(block, DateTime.UtcNow);
+        public void Append(Block<T> block) => Append(
+            block, DateTimeOffset.UtcNow);
 
         public void StageTransactions(ISet<Transaction<T>> txs)
         {
@@ -145,7 +147,7 @@ namespace Libplanet.Blockchain
 
         public Block<T> MineBlock(
             Address rewardBeneficiary,
-            DateTime currentTime
+            DateTimeOffset currentTime
         )
         {
             long index = Store.CountIndex();
@@ -168,7 +170,7 @@ namespace Libplanet.Blockchain
         }
 
         public Block<T> MineBlock(Address rewardBeneficiary) =>
-            MineBlock(rewardBeneficiary, DateTime.UtcNow);
+            MineBlock(rewardBeneficiary, DateTimeOffset.UtcNow);
 
         internal HashDigest<SHA256> FindBranchPoint(BlockLocator locator)
         {

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -62,11 +62,11 @@ namespace Libplanet.Blockchain.Policies
         /// <inheritdoc />
         public InvalidBlockException ValidateBlocks(
             IEnumerable<Block<T>> blocks,
-            DateTime currentTime
+            DateTimeOffset currentTime
         )
         {
             HashDigest<SHA256>? prevHash = null;
-            DateTime? prevTimestamp = null;
+            DateTimeOffset? prevTimestamp = null;
             IEnumerable<(long i, DifficultyExpectation)> indexedDifficulties =
                 ExpectDifficulties(blocks).Select(
                     (exp, i) => { return ((long)i, exp); }
@@ -138,8 +138,8 @@ namespace Libplanet.Blockchain.Policies
         private IEnumerable<DifficultyExpectation> ExpectDifficulties(
             IEnumerable<Block<T>> blocks, bool yieldNext = false)
         {
-            DateTime? prevTimestamp = null;
-            DateTime? prevPrevTimestamp = null;
+            DateTimeOffset? prevTimestamp = null;
+            DateTimeOffset? prevPrevTimestamp = null;
 
             if (yieldNext)
             {

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -25,13 +25,13 @@ namespace Libplanet.Blockchain.Policies
         /// validate.</param>
         /// <param name="currentTime">The current time to be used to validate
         /// of <see cref="Block{T}.Timestamp"/>s.
-        /// Usually <see cref="DateTime.UtcNow"/> is used.</param>
+        /// Usually <see cref="DateTimeOffset.UtcNow"/> is used.</param>
         /// <returns>The reason why the given <paramref name="blocks"/> are
         /// <em>invalid</em>, or <c>null</c> if <paramref name="blocks"/> are
         /// <em>valid</em>.</returns>
         InvalidBlockException ValidateBlocks(
             IEnumerable<Block<T>> blocks,
-            DateTime currentTime
+            DateTimeOffset currentTime
         );
 
         /// <summary>

--- a/Libplanet/Blocks/Block.cs
+++ b/Libplanet/Blocks/Block.cs
@@ -27,7 +27,7 @@ namespace Libplanet.Blocks
             Nonce nonce,
             Address? rewardBeneficiary,
             HashDigest<SHA256>? previousHash,
-            DateTime timestamp,
+            DateTimeOffset timestamp,
             IEnumerable<Transaction<T>> transactions)
         {
             Index = index;
@@ -55,7 +55,7 @@ namespace Libplanet.Blocks
             PreviousHash = (rawBlock.PreviousHash != null)
                 ? new HashDigest<SHA256>(rawBlock.PreviousHash)
                 : default(HashDigest<SHA256>?);
-            Timestamp = DateTime.ParseExact(
+            Timestamp = DateTimeOffset.ParseExact(
                 rawBlock.Timestamp,
                 TimestampFormat,
                 CultureInfo.InvariantCulture).ToUniversalTime();
@@ -94,7 +94,7 @@ namespace Libplanet.Blocks
         public HashDigest<SHA256>? PreviousHash { get; }
 
         [Uno.EqualityIgnore]
-        public DateTime Timestamp { get; }
+        public DateTimeOffset Timestamp { get; }
 
         [Uno.EqualityIgnore]
         public IEnumerable<Transaction<T>> Transactions { get; }
@@ -104,7 +104,7 @@ namespace Libplanet.Blocks
             int difficulty,
             Address rewardBeneficiary,
             HashDigest<SHA256>? previousHash,
-            DateTime timestamp,
+            DateTimeOffset timestamp,
             IEnumerable<Transaction<T>> transactions)
         {
             Block<T> MakeBlock(Nonce n) => new Block<T>(
@@ -150,10 +150,10 @@ namespace Libplanet.Blocks
 
         public void Validate()
         {
-            Validate(DateTime.UtcNow);
+            Validate(DateTimeOffset.UtcNow);
         }
 
-        public void Validate(DateTime currentTime)
+        public void Validate(DateTimeOffset currentTime)
         {
             if (currentTime + TimestampThreshold < Timestamp)
             {

--- a/Libplanet/Net/PeerSetDelta.cs
+++ b/Libplanet/Net/PeerSetDelta.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Net
     {
         public PeerSetDelta(
             Peer sender,
-            DateTime timestamp,
+            DateTimeOffset timestamp,
             IImmutableSet<Peer> addedPeers,
             IImmutableSet<Peer> removedPeers,
             IImmutableSet<Peer> existingPeers)
@@ -27,7 +27,7 @@ namespace Libplanet.Net
         protected PeerSetDelta(SerializationInfo info, StreamingContext context)
         {
             Sender = info.GetValue<Peer>("sender");
-            Timestamp = info.GetValue<DateTime>("timestamp");
+            Timestamp = info.GetValue<DateTimeOffset>("timestamp");
             AddedPeers = info.GetValue<Peer[]>("added_peers")?
                 .ToImmutableHashSet();
             RemovedPeers = info.GetValue<Peer[]>("removed_peers")?
@@ -42,7 +42,7 @@ namespace Libplanet.Net
 
         [Uno.EqualityHash]
         [Uno.EqualityKey]
-        public DateTime Timestamp { get; }
+        public DateTimeOffset Timestamp { get; }
 
         [Uno.EqualityHash]
         public IImmutableSet<Peer> AddedPeers { get; }

--- a/Libplanet/Store/FileStore.cs
+++ b/Libplanet/Store/FileStore.cs
@@ -254,7 +254,7 @@ namespace Libplanet.Store
                     nonce: new Nonce(rawBlock.Nonce),
                     rewardBeneficiary: new Address(rawBlock.RewardBeneficiary),
                     previousHash: previousHash,
-                    timestamp: DateTime.ParseExact(
+                    timestamp: DateTimeOffset.ParseExact(
                         rawBlock.Timestamp,
                         Block<T>.TimestampFormat,
                         CultureInfo.InvariantCulture

--- a/Libplanet/Tx/Transaction.cs
+++ b/Libplanet/Tx/Transaction.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Tx
             Address sender,
             PublicKey publicKey,
             Address recipient,
-            DateTime timestamp,
+            DateTimeOffset timestamp,
             IList<T> actions,
             byte[] signature)
         {
@@ -102,7 +102,7 @@ namespace Libplanet.Tx
             Sender = new Address(rawTx.Sender);
             PublicKey = new PublicKey(rawTx.PublicKey);
             Recipient = new Address(rawTx.Recipient);
-            Timestamp = DateTime.ParseExact(
+            Timestamp = DateTimeOffset.ParseExact(
                 rawTx.Timestamp,
                 TimestampFormat,
                 CultureInfo.InvariantCulture).ToUniversalTime();
@@ -120,7 +120,7 @@ namespace Libplanet.Tx
             Address sender,
             PublicKey publicKey,
             Address recipient,
-            DateTime timestamp,
+            DateTimeOffset timestamp,
             IList<T> actions)
         {
             Sender = sender;
@@ -195,7 +195,7 @@ namespace Libplanet.Tx
         /// <summary>
         /// The time this <see cref="Transaction{T}"/> is created and signed.
         /// </summary>
-        public DateTime Timestamp { get; }
+        public DateTimeOffset Timestamp { get; }
 
         /// <summary>
         /// A <see cref="PublicKey"/> of the account who signs this
@@ -226,8 +226,8 @@ namespace Libplanet.Tx
         /// <summary>
         /// A fa&#xe7;ade factory to create a new <see cref="Transaction{T}"/>.
         /// Unlike the <see cref="Transaction(Address, PublicKey, Address,
-        /// DateTime, IList{T}, byte[])"/> constructor, it automatically signs,
-        /// and fills the appropriate <see cref="Sender"/> and
+        /// DateTimeOffset, IList{T}, byte[])"/> constructor, it automatically
+        /// signs, and fills the appropriate <see cref="Sender"/> and
         /// <see cref="PublicKey"/> properties using the given
         /// <paramref name="privateKey"/>.  However, the <paramref
         /// name="privateKey"/> in itself is not included in the created
@@ -257,7 +257,7 @@ namespace Libplanet.Tx
             PrivateKey privateKey,
             Address recipient,
             IList<T> actions,
-            DateTime timestamp)
+            DateTimeOffset timestamp)
         {
             if (privateKey == null)
             {


### PR DESCRIPTION
It resolves #77.
I replaced all `DateTime` with `DateTimeOffset`, except `ToDateTime` in `Libplanet/Serialization/BencodexFormatterConverter.cs`.
